### PR TITLE
update to error-chain 0.11, and pub use errors::

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,4 +14,4 @@ categories = ["encoding", "parsing"]
 
 [dependencies]
 byteorder = "1.0"
-error-chain = "0.10"
+error-chain = "0.11"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,6 +31,7 @@ extern crate byteorder;
 extern crate error_chain;
 
 pub mod errors;
+pub use errors::*;
 
 mod packet;
 pub use packet::{Packet, PacketHeader};


### PR DESCRIPTION
`error-chain`'s `links` feature unfortunately fails if others are using a different version of `error-chain`, so it's super useful for everyone to be on the same version. Most people seem to be on `0.11`, so upgrade.

Additionally, `error-chain` recommends `pub use errors::*;`, so I've added that.
