### PR TITLE
Don't depend on `backtrace-sys` by default.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,4 +14,4 @@ categories = ["encoding", "parsing"]
 
 [dependencies]
 byteorder = "1.0"
-error-chain = "0.11"
+error-chain = {version = "0.11", default_features=false}


### PR DESCRIPTION
`backtrace-sys` is a cross-compilation buster.

`pcap-file` -> `error_chain` -> `backtrace` -> `backtrace-sys`...

Opting out non-default error_chain's feature allow building pcap-file without backtracing.

If main crate includes error_chain with default features then there would still be backtraces.