### PR TITLE
Added basic fuzzing

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,3 +95,8 @@ $ cargo fuzz run pcap_parser
 $ cargo fuzz run pcap_ng_parser
 ```
 Keep in mind that libfuzzer by default uses only one core, so you can either run all the harnesses in different terminals, or you can pass the `-jobs` and `-workers` attributes. More info can be found in its documentation [here](https://llvm.org/docs/LibFuzzer.html).
+To get better crash reports add to you rust flags: `-Zsanitizer=address`. 
+E.g.
+```bash
+RUSTFLAGS="-Zsanitizer=address" cargo fuzz run pcap_reader
+```

--- a/README.md
+++ b/README.md
@@ -82,3 +82,16 @@ Licensed under MIT.
 To test the library I used the excellent PcapNg testing suite provided by [hadrielk](https://github.com/hadrielk/pcapng-test-generator). 
 
 
+# Fuzzing
+Currently there are 4 crude harnesses to check that the parser won't panic in any situation. To start fuzzing you must install `cargo-fuzz` with the command:
+```bash
+$ cargo install cargo-fuzz
+```
+And then, in the root of the repository, you can run the harnesses as:
+```bash
+$ cargo fuzz run pcap_reader
+$ cargo fuzz run pcap_ng_reader
+$ cargo fuzz run pcap_parser
+$ cargo fuzz run pcap_ng_parser
+```
+Keep in mind that libfuzzer by default uses only one core, so you can either run all the harnesses in different terminals, or you can pass the `-jobs` and `-workers` attributes. More info can be found in its documentation [here](https://llvm.org/docs/LibFuzzer.html).

--- a/fuzz/.gitignore
+++ b/fuzz/.gitignore
@@ -1,0 +1,4 @@
+
+target
+corpus
+artifacts

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -1,0 +1,44 @@
+
+[package]
+name = "pcap-file-fuzz"
+version = "0.0.0"
+authors = ["Automatically generated"]
+publish = false
+edition = "2018"
+
+[package.metadata]
+cargo-fuzz = true
+
+[dependencies]
+libfuzzer-sys = "0.3"
+
+[dependencies.pcap-file]
+path = ".."
+
+# Prevent this from interfering with workspaces
+[workspace]
+members = ["."]
+
+[[bin]]
+name = "pcap_parser"
+path = "fuzz_targets/pcap_parser.rs"
+test = false
+doc = false
+
+[[bin]]
+name = "pcap_ng_parser"
+path = "fuzz_targets/pcap_ng_parser.rs"
+test = false
+doc = false
+
+[[bin]]
+name = "pcap_reader"
+path = "fuzz_targets/pcap_reader.rs"
+test = false
+doc = false
+
+[[bin]]
+name = "pcap_ng_reader"
+path = "fuzz_targets/pcap_ng_reader.rs"
+test = false
+doc = false

--- a/fuzz/fuzz_targets/pcap_ng_parser.rs
+++ b/fuzz/fuzz_targets/pcap_ng_parser.rs
@@ -1,0 +1,14 @@
+#![no_main]
+use libfuzzer_sys::fuzz_target;
+use pcap_file::PcapNgParser;
+
+fuzz_target!(|data: &[u8]| {
+    if let Ok((rem, pcap_parser)) = PcapNgParser::new(data) {
+        let mut src = rem;
+
+        while !src.is_empty() {
+            let _ = pcap_parser.next_packet(src);
+            src = &src[1..];
+        }
+    }
+});

--- a/fuzz/fuzz_targets/pcap_ng_reader.rs
+++ b/fuzz/fuzz_targets/pcap_ng_reader.rs
@@ -1,0 +1,13 @@
+#![no_main]
+use libfuzzer_sys::fuzz_target;
+use pcap_file::PcapNgReader;
+
+fuzz_target!(|data: &[u8]| {
+    if let Ok(pcap_reader) = PcapNgReader::new(data) {
+        for maybe_block in pcap_reader {
+            if let Ok(block) = maybe_block {
+                let _ = block.parsed();
+            }
+        }
+    }
+});

--- a/fuzz/fuzz_targets/pcap_parser.rs
+++ b/fuzz/fuzz_targets/pcap_parser.rs
@@ -1,0 +1,14 @@
+#![no_main]
+use libfuzzer_sys::fuzz_target;
+use pcap_file::PcapParser;
+
+fuzz_target!(|data: &[u8]| {
+    if let Ok((rem, pcap_parser)) = PcapParser::new(data) {
+        let mut src = rem;
+
+        while !src.is_empty() {
+            let _ = pcap_parser.next_packet(src);
+            src = &src[1..];
+        }
+    }
+});

--- a/fuzz/fuzz_targets/pcap_reader.rs
+++ b/fuzz/fuzz_targets/pcap_reader.rs
@@ -1,0 +1,11 @@
+#![no_main]
+use libfuzzer_sys::fuzz_target;
+use pcap_file::PcapReader;
+
+fuzz_target!(|data: &[u8]| {
+    if let Ok(pcap_reader) = PcapReader::new(data) {
+        for _ in pcap_reader {
+
+        }
+    }
+});


### PR DESCRIPTION
Hi, thank you for writing this library. 

I've added some basic fuzzing for the library, this way we can ensure that the library will not panic under any circumstance. I wrote a little tutorial on how to fuzz the library in the `README.md`.

Currently it finds a mutiplication with overflow at `pcap-file/src/pcap/packet.rs:51:13`,
the minimum input that reproduce this error is:
```rust
let data = [
    161, 178, 195, 212,  // Timestamp (Seconds)
    0, 0, 0, 0,  // Timestamp (microseconds or nanoseconds)
    0, 0, 1, 0,  // Captured Packet Length
    0, 1, 0, 0,  // Original Packet Length

    // Packet Data
    0, 0, 1, 0, 0, 0, 0, 1, 
    0, 0, 0, 0, 12, 0, 1, 0, 0
];

if let Ok(pcap_reader) = PcapNgReader::new(data) {
    for maybe_block in pcap_reader {
        if let Ok(block) = maybe_block {
            let _ = block.parsed();
        }
    }
}
```

The error is at this line:
```rust
if ts_resolution == TsResolution::MicroSecond {
    ts_nsec *= 1000;
}
```

This error was found running:
```bash
$ RUST_BACKTRACE=1 RUSTFLAGS="-Zsanitizer=address" cargo fuzz run pcap_reader
```

I understand that these are **not urgent bugs**, but I wrote these harnesses to debug my application and I thought that you might enjoy them too.
