### PR TITLE
Respect Snaplen

### DIFF
--- a/src/pcap/parser.rs
+++ b/src/pcap/parser.rs
@@ -68,8 +68,8 @@ impl PcapParser {
         let ts_resolution = self.header.ts_resolution();
 
         match self.header.endianness() {
-            Endianness::Big => Packet::from_slice::<BigEndian>(slice, ts_resolution),
-            Endianness::Little => Packet::from_slice::<LittleEndian>(slice, ts_resolution)
+            Endianness::Big => Packet::from_slice::<BigEndian>(&self.header, slice, ts_resolution),
+            Endianness::Little => Packet::from_slice::<LittleEndian>(&self.header, slice, ts_resolution)
         }
     }
 }

--- a/src/pcap/reader.rs
+++ b/src/pcap/reader.rs
@@ -108,8 +108,8 @@ impl <T:Read> Iterator for PcapReader<T> {
 
         Some(
             match self.header.endianness() {
-                Endianness::Big => Packet::from_reader::<_, BigEndian>(&mut self.reader, ts_resolution),
-                Endianness::Little => Packet::from_reader::<_, LittleEndian>(&mut self.reader, ts_resolution)
+                Endianness::Big => Packet::from_reader::<_, BigEndian>(&self.header, &mut self.reader, ts_resolution),
+                Endianness::Little => Packet::from_reader::<_, LittleEndian>(&self.header, &mut self.reader, ts_resolution)
             }
         )
     }


### PR DESCRIPTION
In the pcap format, the maximum packet length is in the Pcap file header - so use this instead of hardcoding 0xFFFF!