### PR TITLE
feat(pcap): add getter for writer snaplen

### DIFF
--- a/src/pcap/writer.rs
+++ b/src/pcap/writer.rs
@@ -103,4 +103,10 @@ impl<W: Write> PcapWriter<W> {
             Endianness::Little => packet.write_to::<_, LittleEndian>(&mut self.writer),
         }
     }
+
+    /// Returns a SnapLen, i.e. an unsigned value indicating the maximum number of octets captured
+    /// from each packet
+    pub fn get_snaplen(&self) -> usize {
+        self.snaplen as usize
+    }
 }


### PR DESCRIPTION
Add getter method to obtain PcapWriter snaplen, which is only a property of PcapHeader. 