### PR TITLE
Enhanced Packet Blocks have micros timestamp by default

### DIFF
--- a/src/pcapng/blocks/enhanced_packet.rs
+++ b/src/pcapng/blocks/enhanced_packet.rs
@@ -62,7 +62,7 @@ impl<'a> PcapNgBlock<'a> for EnhancedPacketBlock<'a> {
         let (slice, options) = EnhancedPacketOption::opts_from_slice::<B>(slice)?;
         let block = EnhancedPacketBlock {
             interface_id,
-            timestamp: Duration::from_nanos(timestamp),
+            timestamp: Duration::from_micros(timestamp),
             original_len,
             data: Cow::Borrowed(data),
             options,
@@ -76,7 +76,7 @@ impl<'a> PcapNgBlock<'a> for EnhancedPacketBlock<'a> {
 
         writer.write_u32::<B>(self.interface_id)?;
 
-        let timestamp = self.timestamp.as_nanos();
+        let timestamp = self.timestamp.as_micros();
         let timestamp_high = (timestamp >> 32) as u32;
         writer.write_u32::<B>(timestamp_high)?;
         let timestamp_low = (timestamp & 0xFFFFFFFF) as u32;


### PR DESCRIPTION
The default according to https://www.ietf.org/staging/draft-tuexen-opsawg-pcapng-02.html#format_idb seems to be a micros timestamp.

Considering that this should actually honour the setting in the interface descriptor block but doesn't it might be safer to assume the default.

Considering the following code. With this fix the timestamps are as expected, without it we are time travelling to the year 56000 something.

```                let duration_since_epoch = match SystemTime::now().duration_since(SystemTime::UNIX_EPOCH) {
                    Ok(dt) => dt,
                    Err(_) => panic!("SystemTime before UNIX EPOCH!"),
                };

                let idb = InterfaceDescriptionBlock {
                    linktype: DataLink::IEEE802_15_4_NOFCS,
                    snaplen: 0,
                    options: vec![],
                };

                let packet = EnhancedPacketBlock {
                    interface_id: 0,
                    timestamp: duration_since_epoch,
                    original_len: n.len() as u32,
                    data: Cow::from(n.as_slice()),
                    options: vec![],
                };

                pcap_ng_writer.write_block(&idb.into_block()).unwrap();
                pcap_ng_writer.write_block(&packet.into_block()).unwrap();
```