### PR TITLE
impl AsRef & AsMut for ReadBuffer/PcapReader/PcapNgReader

### DIFF
--- a/src/pcap/reader.rs
+++ b/src/pcap/reader.rs
@@ -5,7 +5,6 @@ use crate::errors::*;
 use crate::pcap::{PcapHeader, PcapPacket};
 use crate::read_buffer::ReadBuffer;
 
-
 /// Reads a pcap from a reader.
 ///
 /// # Example
@@ -61,8 +60,7 @@ impl<R: Read> PcapReader<R> {
             Ok(has_data) => {
                 if has_data {
                     Some(self.reader.parse_with(|src| self.parser.next_packet(src)))
-                }
-                else {
+                } else {
                     None
                 }
             },
@@ -76,8 +74,7 @@ impl<R: Read> PcapReader<R> {
             Ok(has_data) => {
                 if has_data {
                     Some(self.reader.parse_with(|src| self.parser.next_raw_packet(src)))
-                }
-                else {
+                } else {
                     None
                 }
             },
@@ -88,5 +85,17 @@ impl<R: Read> PcapReader<R> {
     /// Returns the global header of the pcap.
     pub fn header(&self) -> PcapHeader {
         self.parser.header()
+    }
+}
+
+impl<R: Read> AsRef<R> for PcapReader<R> {
+    fn as_ref(&self) -> &R {
+        self.reader.as_ref()
+    }
+}
+
+impl<R: Read> AsMut<R> for PcapReader<R> {
+    fn as_mut(&mut self) -> &mut R {
+        self.reader.as_mut()
     }
 }

--- a/src/pcapng/reader.rs
+++ b/src/pcapng/reader.rs
@@ -8,7 +8,6 @@ use super::PcapNgParser;
 use crate::errors::PcapError;
 use crate::read_buffer::ReadBuffer;
 
-
 /// Reads a PcapNg from a reader.
 ///
 /// # Example
@@ -49,8 +48,7 @@ impl<R: Read> PcapNgReader<R> {
             Ok(has_data) => {
                 if has_data {
                     Some(self.reader.parse_with(|src| self.parser.next_block(src)))
-                }
-                else {
+                } else {
                     None
                 }
             },
@@ -64,8 +62,7 @@ impl<R: Read> PcapNgReader<R> {
             Ok(has_data) => {
                 if has_data {
                     Some(self.reader.parse_with(|src| self.parser.next_raw_block(src)))
-                }
-                else {
+                } else {
                     None
                 }
             },
@@ -92,9 +89,16 @@ impl<R: Read> PcapNgReader<R> {
     pub fn into_inner(self) -> R {
         self.reader.into_inner()
     }
+}
 
-    /// Gets a reference to the wrapped reader.
-    pub fn get_ref(&self) -> &R {
-        self.reader.get_ref()
+impl<R: Read> AsRef<R> for PcapNgReader<R> {
+    fn as_ref(&self) -> &R {
+        self.reader.as_ref()
+    }
+}
+
+impl<R: Read> AsMut<R> for PcapNgReader<R> {
+    fn as_mut(&mut self) -> &mut R {
+        self.reader.as_mut()
     }
 }

--- a/src/read_buffer.rs
+++ b/src/read_buffer.rs
@@ -2,7 +2,6 @@ use std::io::{Error, ErrorKind, Read};
 
 use crate::PcapError;
 
-
 /// Internal structure that bufferize its input and allow to parse element from its buffer.
 #[derive(Debug)]
 pub(crate) struct ReadBuffer<R: Read> {
@@ -124,10 +123,17 @@ impl<R: Read> ReadBuffer<R> {
     pub fn into_inner(self) -> R {
         self.reader
     }
+}
 
-    /// Return a reference over the inner reader
-    pub fn get_ref(&self) -> &R {
+impl<R: Read> AsRef<R> for ReadBuffer<R> {
+    fn as_ref(&self) -> &R {
         &self.reader
+    }
+}
+
+impl<R: Read> AsMut<R> for ReadBuffer<R> {
+    fn as_mut(&mut self) -> &mut R {
+        &mut self.reader
     }
 }
 


### PR DESCRIPTION
Implement AsRef & AsMut for ReadBuffer/PcapReader/PcapNgReader

Internal Read trait is very useful in some cases, only having into_reader/get_ref is not enough, implement these two trait for convenience