### PR TITLE
Fix snaplen

### DIFF
--- a/src/pcap/mod.rs
+++ b/src/pcap/mod.rs
@@ -11,3 +11,8 @@ pub use packet::*;
 pub use parser::*;
 pub use reader::*;
 pub use writer::*;
+
+/// The tcpdump group has changed max snapshot length from 65535 to 262144 and used it as default.
+/// see [code](https://github.com/the-tcpdump-group/tcpdump/blob/87c90012f079200b7d49979164e8e9ed89d93d9d/netdissect.h#L342C9-L342C25)
+/// default snapshot length 262144 = 2^18
+const MAXIMUM_SNAPLEN: u32 = 262144;

--- a/src/pcap/writer.rs
+++ b/src/pcap/writer.rs
@@ -7,7 +7,6 @@ use crate::errors::*;
 use crate::pcap::{PcapHeader, PcapPacket};
 use crate::{Endianness, TsResolution};
 
-
 /// Writes a pcap to a writer.
 ///
 /// # Example
@@ -51,7 +50,7 @@ impl<W: Write> PcapWriter<W> {
     ///     version_minor: 4,
     ///     ts_correction: 0,
     ///     ts_accuracy: 0,
-    ///     snaplen: 65535,
+    ///     snaplen: MAXIMUM_SNAPLEN,
     ///     datalink: DataLink::ETHERNET,
     ///     ts_resolution: TsResolution::MicroSecond,
     ///     endianness: Endianness::Native

--- a/tests/pcap/little_endian_zero_snaplen.pcap
+++ b/tests/pcap/little_endian_zero_snaplen.pcap
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b035f3675fafd9a21c093ad3db927b2384c88a985ce4ebdedf66c0959ffcc5e2
+size 1455


### PR DESCRIPTION
1. Change maximum snaplen to 262144 just like [tcpdump](https://github.com/the-tcpdump-group/tcpdump/blob/87c90012f079200b7d49979164e8e9ed89d93d9d/netdissect.h#L342C9-L342C25) and [tshark](https://github.com/wireshark/wireshark/blob/36a9f4231b3ee82bd4efee53ed8a1004ff90102d/doc/tshark.adoc?plain=1#L790).
2. Fix parsing error when snaplen is 0.  

> A value of 0 specifies a snapshot length of 262144, so that the full packet is captured; this is the default.
> from https://www.wireshark.org/docs/man-pages/tshark.html