### PR TITLE
fix(pcapng): Timestamp resolution handling

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ exclude = ["benches/bench.pcap", "benches/bench.pcapng", "fuzz", "tests"]
 [dependencies]
 byteorder_slice = "3.0.0"
 derive-into-owned = "0.2.0"
+once_cell = "1.19.0"
 thiserror = "1.0.35"
 
 [dev-dependencies]

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -11,7 +11,7 @@ pub enum PcapError {
     IncompleteBuffer,
 
     /// Generic IO error
-    #[error("Error reading bytes")]
+    #[error("Error reading/writing bytes")]
     IoError(#[source] std::io::Error),
 
     /// Invalid field
@@ -27,8 +27,16 @@ pub enum PcapError {
     FromUtf8Error(#[source] std::string::FromUtf8Error),
 
     /// Invalid interface ID (only for Pcap NG)
-    #[error("No corresponding interface id: {0}")]
+    #[error("The interface id ({0}) of the current block doesn't exists")]
     InvalidInterfaceId(u32),
+
+    /// Invalid timestamp resolution (only for Pcap NG)
+    #[error("Invalid timestamp resolution: {0} is not in [0-9]")]
+    InvalidTsResolution(u8),
+
+    /// The packet's timestamp is too big (only for Pcap NG)
+    #[error("Packet's timestamp too big, please choose a bigger timestamp resolution")]
+    TimestampTooBig,
 }
 
 impl From<std::str::Utf8Error> for PcapError {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,5 @@
 #![allow(clippy::unreadable_literal)]
-#![deny(missing_docs)]
+#![warn(missing_docs)]
 
 //! Provides parsers, readers and writers for Pcap and PcapNg files.
 //!

--- a/src/pcapng/blocks/block_common.rs
+++ b/src/pcapng/blocks/block_common.rs
@@ -133,7 +133,7 @@ impl<'a> RawBlock<'a> {
         writer.write_all(&self.body[..])?;
         writer.write_u32::<B>(self.trailer_len)?;
 
-        Ok(self.body.len() + 6)
+        Ok(self.body.len() + 12)
     }
 
     /// Tries to convert a [`RawBlock`] into a [`Block`]
@@ -259,8 +259,24 @@ impl<'a> Block<'a> {
         }
     }
 
+    /// Tries to downcasts the current block as an [`EnhancedPacketBlock`]
+    pub fn as_enhanced_packet(&self) -> Option<&EnhancedPacketBlock<'a>> {
+        match self {
+            Block::EnhancedPacket(a) => Some(a),
+            _ => None,
+        }
+    }
+
     /// Tries to downcasts the current block into an [`InterfaceDescriptionBlock`]
     pub fn into_interface_description(self) -> Option<InterfaceDescriptionBlock<'a>> {
+        match self {
+            Block::InterfaceDescription(a) => Some(a),
+            _ => None,
+        }
+    }
+
+    /// Tries to downcasts the current block as an [`InterfaceDescriptionBlock`]
+    pub fn as_interface_description(&self) -> Option<&InterfaceDescriptionBlock<'a>> {
         match self {
             Block::InterfaceDescription(a) => Some(a),
             _ => None,
@@ -275,7 +291,15 @@ impl<'a> Block<'a> {
         }
     }
 
-    /// Tries to downcast the current block into an [`NameResolutionBlock`], if possible
+    /// Tries to downcasts the current block as an [`InterfaceStatisticsBlock`]
+    pub fn as_interface_statistics(&self) -> Option<&InterfaceStatisticsBlock<'a>> {
+        match self {
+            Block::InterfaceStatistics(a) => Some(a),
+            _ => None,
+        }
+    }
+
+    /// Tries to downcast the current block into a [`NameResolutionBlock`], if possible
     pub fn into_name_resolution(self) -> Option<NameResolutionBlock<'a>> {
         match self {
             Block::NameResolution(a) => Some(a),
@@ -283,7 +307,15 @@ impl<'a> Block<'a> {
         }
     }
 
-    /// Tries to downcast the current block into an [`PacketBlock`], if possible
+    /// Tries to downcast the current block as a [`NameResolutionBlock`], if possible
+    pub fn as_name_resolution(&self) -> Option<&NameResolutionBlock<'a>> {
+        match self {
+            Block::NameResolution(a) => Some(a),
+            _ => None,
+        }
+    }
+
+    /// Tries to downcast the current block into a [`PacketBlock`], if possible
     pub fn into_packet(self) -> Option<PacketBlock<'a>> {
         match self {
             Block::Packet(a) => Some(a),
@@ -291,7 +323,15 @@ impl<'a> Block<'a> {
         }
     }
 
-    /// Tries to downcast the current block into an [`SectionHeaderBlock`], if possible
+    /// Tries to downcast the current block as a [`PacketBlock`], if possible
+    pub fn as_packet(&self) -> Option<&PacketBlock<'a>> {
+        match self {
+            Block::Packet(a) => Some(a),
+            _ => None,
+        }
+    }
+
+    /// Tries to downcast the current block into a [`SectionHeaderBlock`], if possible
     pub fn into_section_header(self) -> Option<SectionHeaderBlock<'a>> {
         match self {
             Block::SectionHeader(a) => Some(a),
@@ -299,7 +339,15 @@ impl<'a> Block<'a> {
         }
     }
 
-    /// Tries to downcast the current block into an [`SimplePacketBlock`], if possible
+    /// Tries to downcast the current block as a [`SectionHeaderBlock`], if possible
+    pub fn as_section_header(&self) -> Option<&SectionHeaderBlock<'a>> {
+        match self {
+            Block::SectionHeader(a) => Some(a),
+            _ => None,
+        }
+    }
+
+    /// Tries to downcast the current block into a [`SimplePacketBlock`], if possible
     pub fn into_simple_packet(self) -> Option<SimplePacketBlock<'a>> {
         match self {
             Block::SimplePacket(a) => Some(a),
@@ -307,8 +355,24 @@ impl<'a> Block<'a> {
         }
     }
 
-    /// Tries to downcast the current block into an [`SystemdJournalExportBlock`], if possible
+    /// Tries to downcast the current block as a [`SimplePacketBlock`], if possible
+    pub fn as_simple_packet(&self) -> Option<&SimplePacketBlock<'a>> {
+        match self {
+            Block::SimplePacket(a) => Some(a),
+            _ => None,
+        }
+    }
+
+    /// Tries to downcast the current block into a [`SystemdJournalExportBlock`], if possible
     pub fn into_systemd_journal_export(self) -> Option<SystemdJournalExportBlock<'a>> {
+        match self {
+            Block::SystemdJournalExport(a) => Some(a),
+            _ => None,
+        }
+    }
+
+    /// Tries to downcast the current block as a [`SystemdJournalExportBlock`], if possible
+    pub fn as_systemd_journal_export(&self) -> Option<&SystemdJournalExportBlock<'a>> {
         match self {
             Block::SystemdJournalExport(a) => Some(a),
             _ => None,

--- a/tests/test_multiple_interfaces.pcapng
+++ b/tests/test_multiple_interfaces.pcapng
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ddd3bd080fab8677ad23bb39f6e6f53f4b438f4177560ef7183286e5eb7c76f9
+size 3296

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -1,4 +1,43 @@
 #![allow(clippy::unreadable_literal)]
 
+use std::{fs::File, time::Duration};
+
+use pcap_file::pcapng::{PcapNgReader, blocks::interface_description::InterfaceDescriptionOption};
+
 mod pcap;
 mod pcapng;
+
+
+/// Test that the timestamp resolution is correctly read and set in the packets.
+#[test]
+fn timestamp_resolution() {
+    let file = File::open("tests/test_multiple_interfaces.pcapng").unwrap();
+    let mut pcapng_reader = PcapNgReader::new(file).unwrap();
+
+    let mut i = 0;
+    while let Some(block) = pcapng_reader.next_block() {
+        let block = block.unwrap_or_else(|_| panic!("Error on block {i}"));
+        
+        match i {
+            0 => {
+                let if_en0 = block.as_interface_description().expect("Block 0 should be an InterfaceDescriptionBlock");
+                assert!(matches!(if_en0.options[2], InterfaceDescriptionOption::IfTsResol(9)), "Invalid TsResolution for block 0");
+            },
+            7=> {
+                let if_utun4 = block.as_interface_description().expect("Block 7 should be an InterfaceDescriptionBlock");
+                assert_eq!(if_utun4.options[1], InterfaceDescriptionOption::IfTsResol(6), "Invalid TsResolution for block 7");
+            },
+            8 => {
+                let pkt_0 = block.as_enhanced_packet().expect("Block 8 should be an EnhancedPacketBlock");
+                assert_eq!(pkt_0.timestamp, Duration::new(1704187433, 103553000), "Invalid timestamp for pkt0");
+            },
+            10 => {
+                let pkt_2 = block.as_enhanced_packet().expect("Block 10 should be an EnhancedPacketBlock");
+                assert_eq!(pkt_2.timestamp, Duration::new(1704187, 433132051), "Invalid timestamp for pkt2");
+            },
+            _ => {}
+        }
+
+        i += 1;
+    }
+}


### PR DESCRIPTION
The EnhancedPacketBlock have a variable timestamp resolution defined in the corresponding InterfaceDescriptionBlock. This commit add support for the timestamp resolution. If no timestamp resolution is set, default to micro-seconds.

ADD
 - EnhancedPacket timestamp resolution support (read and write)
 - TsResolution struct
 - Block::as_\*\*\*\*_block() function (borrowed counterparts to Block::into_\*\*\*\*_block() functions)

BREAKING CHANGE

PcapError: Add variants
EnhancedPacketBlock: Add field