### PR TITLE
PcapNgReader reports "Invalid field value: Invalid option",

### DIFF
--- a/src/pcapng/blocks/opt_common.rs
+++ b/src/pcapng/blocks/opt_common.rs
@@ -37,7 +37,7 @@ pub(crate) trait PcapNgOption<'a> {
             let length = slice.read_u16::<B>().unwrap() as usize;
             let pad_len = (4 - (length % 4)) % 4;
 
-            if code == 0 {
+            if code == 0 || slice.len() == length + pad_len {
                 return Ok((slice, options));
             }
 


### PR DESCRIPTION
This fixes the unnecessary failure, while reading block options that are not terminated by a opt_endofopt option.

According to https://www.ietf.org/archive/id/draft-tuexen-opsawg-pcapng-05.html:

  Code that reads pcapng files MUST NOT assume an option list will have an
  opt_endofopt option at the end; it MUST also check for the end of the block ...