### PR TITLE
Support non-static lifetimes for PcapNgWriter blocks

### DIFF
--- a/src/pcapng/writer.rs
+++ b/src/pcapng/writer.rs
@@ -33,11 +33,11 @@ use crate::{Endianness, PcapError, PcapResult};
 ///     pcapng_writer.write_block(&block).unwrap();
 /// }
 /// ```
-pub struct PcapNgWriter<W: Write> {
+pub struct PcapNgWriter<'s, W: Write> {
     /// Current section of the pcapng
-    section: SectionHeaderBlock<'static>,
+    section: SectionHeaderBlock<'s>,
     /// List of the interfaces of the current section of the pcapng
-    interfaces: Vec<InterfaceDescriptionBlock<'static>>,
+    interfaces: Vec<InterfaceDescriptionBlock<'s>>,
     /// Timestamp resolutions corresponding to the interfaces
     ts_resolutions: Vec<TsResolution>,
 
@@ -45,7 +45,7 @@ pub struct PcapNgWriter<W: Write> {
     writer: W,
 }
 
-impl<W: Write> PcapNgWriter<W> {
+impl<'s, W: Write> PcapNgWriter<'s, W> {
     /// Create a new [`PcapNgWriter`] from an existing writer.
     ///
     /// Default to the native endianness of the CPU.
@@ -76,7 +76,7 @@ impl<W: Write> PcapNgWriter<W> {
     }
 
     /// Create a new [`PcapNgWriter`] from an existing writer with the given section header.
-    pub fn with_section_header(mut writer: W, section: SectionHeaderBlock<'static>) -> PcapResult<Self> {
+    pub fn with_section_header(mut writer: W, section: SectionHeaderBlock<'s>) -> PcapResult<Self> {
         match section.endianness {
             Endianness::Big => section.clone().into_block().write_to::<BigEndian, _>(&mut writer).map_err(PcapError::IoError)?,
             Endianness::Little => section.clone().into_block().write_to::<LittleEndian, _>(&mut writer).map_err(PcapError::IoError)?,
@@ -224,12 +224,12 @@ impl<W: Write> PcapNgWriter<W> {
     }
 
     /// Return the current [`SectionHeaderBlock`].
-    pub fn section(&self) -> &SectionHeaderBlock<'static> {
+    pub fn section(&self) -> &SectionHeaderBlock<'_> {
         &self.section
     }
 
     /// Return all the current [`InterfaceDescriptionBlock`].
-    pub fn interfaces(&self) -> &[InterfaceDescriptionBlock<'static>] {
+    pub fn interfaces(&self) -> &[InterfaceDescriptionBlock<'_>] {
         &self.interfaces
     }
 }


### PR DESCRIPTION
The `SectionHeaderBlock` passed to `PcapNgWriter::with_section_header` is currently required to have a `'static` lifetime.

This effectively means that the initial section header must be a constant. It is not currently possible to use `PcapNgWriter` to write a PcapNg file with an initial section header that is constructed at runtime, e.g. to store a comment entered by the user with the `SectionHeaderOption::Comment` option.

This PR adds a lifetime parameter to the `PcapNgWriter` type, so that a writer can be constructed using section headers and interface description blocks that have non-static lifetimes.

I believe this change should be backwards compatible with existing code, as the lifetime parameter is inferred automatically. In all existing use cases the lifetime parameter should just be inferred to be `'static`, but having the parameter makes it possible to also construct the type with shorter lifetimes.