### PR TITLE
Correct timestamp handling for all fields and options

### DIFF
--- a/src/errors.rs
+++ b/src/errors.rs
@@ -50,3 +50,9 @@ impl From<std::string::FromUtf8Error> for PcapError {
         PcapError::FromUtf8Error(err)
     }
 }
+
+impl From<std::io::Error> for PcapError {
+    fn from(err: std::io::Error) -> Self {
+        PcapError::IoError(err)
+    }
+}

--- a/src/pcapng/blocks/enhanced_packet.rs
+++ b/src/pcapng/blocks/enhanced_packet.rs
@@ -60,7 +60,7 @@ impl<'a> PcapNgBlock<'a> for EnhancedPacketBlock<'a> {
         let data = &slice[..captured_len as usize];
         slice = &slice[tot_len..];
 
-        let (slice, options) = EnhancedPacketOption::opts_from_slice::<B>(slice)?;
+        let (slice, options) = EnhancedPacketOption::opts_from_slice::<B>(state, Some(interface_id), slice)?;
         let block = EnhancedPacketBlock {
             interface_id,
             timestamp,
@@ -126,7 +126,7 @@ pub enum EnhancedPacketOption<'a> {
 }
 
 impl<'a> PcapNgOption<'a> for EnhancedPacketOption<'a> {
-    fn from_slice<B: ByteOrder>(code: u16, length: u16, mut slice: &'a [u8]) -> Result<Self, PcapError> {
+    fn from_slice<B: ByteOrder>(_state: &PcapNgState, _interface_id: Option<u32>, code: u16, length: u16, mut slice: &'a [u8]) -> Result<Self, PcapError> {
         let opt = match code {
             1 => EnhancedPacketOption::Comment(Cow::Borrowed(std::str::from_utf8(slice)?)),
             2 => {

--- a/src/pcapng/blocks/enhanced_packet.rs
+++ b/src/pcapng/blocks/enhanced_packet.rs
@@ -84,7 +84,7 @@ impl<'a> PcapNgBlock<'a> for EnhancedPacketBlock<'a> {
         writer.write_all(&self.data)?;
         writer.write_all(&[0_u8; 3][..pad_len])?;
 
-        let opt_len = EnhancedPacketOption::write_opts_to::<B, W>(&self.options, writer)?;
+        let opt_len = EnhancedPacketOption::write_opts_to::<B, W>(&self.options, state, Some(self.interface_id), writer)?;
 
         Ok(20 + &self.data.len() + pad_len + opt_len)
     }
@@ -152,7 +152,7 @@ impl<'a> PcapNgOption<'a> for EnhancedPacketOption<'a> {
         Ok(opt)
     }
 
-    fn write_to<B: ByteOrder, W: Write>(&self, writer: &mut W) -> IoResult<usize> {
+    fn write_to<B: ByteOrder, W: Write>(&self, _state: &PcapNgState, _interface_id: Option<u32>, writer: &mut W) -> IoResult<usize> {
         match self {
             EnhancedPacketOption::Comment(a) => a.write_opt_to::<B, W>(1, writer),
             EnhancedPacketOption::Flags(a) => a.write_opt_to::<B, W>(2, writer),

--- a/src/pcapng/blocks/enhanced_packet.rs
+++ b/src/pcapng/blocks/enhanced_packet.rs
@@ -1,7 +1,7 @@
 //! Enhanced Packet Block (EPB).
 
 use std::borrow::Cow;
-use std::io::{Result as IoResult, Write};
+use std::io::Write;
 use std::time::Duration;
 
 use byteorder_slice::byteorder::WriteBytesExt;
@@ -72,7 +72,7 @@ impl<'a> PcapNgBlock<'a> for EnhancedPacketBlock<'a> {
         Ok((slice, block))
     }
 
-    fn write_to<B: ByteOrder, W: Write>(&self, state: &PcapNgState, writer: &mut W) -> IoResult<usize> {
+    fn write_to<B: ByteOrder, W: Write>(&self, state: &PcapNgState, writer: &mut W) -> Result<usize, PcapError> {
         let pad_len = (4 - (&self.data.len() % 4)) % 4;
 
         writer.write_u32::<B>(self.interface_id)?;
@@ -152,8 +152,8 @@ impl<'a> PcapNgOption<'a> for EnhancedPacketOption<'a> {
         Ok(opt)
     }
 
-    fn write_to<B: ByteOrder, W: Write>(&self, _state: &PcapNgState, _interface_id: Option<u32>, writer: &mut W) -> IoResult<usize> {
-        match self {
+    fn write_to<B: ByteOrder, W: Write>(&self, _state: &PcapNgState, _interface_id: Option<u32>, writer: &mut W) -> Result<usize, PcapError> {
+        Ok(match self {
             EnhancedPacketOption::Comment(a) => a.write_opt_to::<B, W>(1, writer),
             EnhancedPacketOption::Flags(a) => a.write_opt_to::<B, W>(2, writer),
             EnhancedPacketOption::Hash(a) => a.write_opt_to::<B, W>(3, writer),
@@ -161,6 +161,6 @@ impl<'a> PcapNgOption<'a> for EnhancedPacketOption<'a> {
             EnhancedPacketOption::CustomBinary(a) => a.write_opt_to::<B, W>(a.code, writer),
             EnhancedPacketOption::CustomUtf8(a) => a.write_opt_to::<B, W>(a.code, writer),
             EnhancedPacketOption::Unknown(a) => a.write_opt_to::<B, W>(a.code, writer),
-        }
+        }?)
     }
 }

--- a/src/pcapng/blocks/enhanced_packet.rs
+++ b/src/pcapng/blocks/enhanced_packet.rs
@@ -45,10 +45,7 @@ impl<'a> PcapNgBlock<'a> for EnhancedPacketBlock<'a> {
 
         let interface_id = slice.read_u32::<B>().unwrap();
 
-        let timestamp_high = slice.read_u32::<B>().unwrap() as u64;
-        let timestamp_low = slice.read_u32::<B>().unwrap() as u64;
-        let ts_raw = (timestamp_high << 32) + timestamp_low;
-        let timestamp = state.decode_timestamp(interface_id, ts_raw)?;
+        let timestamp = state.decode_timestamp::<B>(interface_id, &mut slice)?;
 
         let captured_len = slice.read_u32::<B>().unwrap();
         let original_len = slice.read_u32::<B>().unwrap();
@@ -80,12 +77,7 @@ impl<'a> PcapNgBlock<'a> for EnhancedPacketBlock<'a> {
 
         writer.write_u32::<B>(self.interface_id)?;
 
-        let ts_raw = state.encode_timestamp(self.interface_id, self.timestamp)?;
-
-        let timestamp_high = (ts_raw >> 32) as u32;
-        let timestamp_low = (ts_raw & 0xFFFFFFFF) as u32;
-        writer.write_u32::<B>(timestamp_high)?;
-        writer.write_u32::<B>(timestamp_low)?;
+        state.encode_timestamp::<B, W>(self.interface_id, self.timestamp, writer)?;
 
         writer.write_u32::<B>(self.data.len() as u32)?;
         writer.write_u32::<B>(self.original_len)?;

--- a/src/pcapng/blocks/interface_description.rs
+++ b/src/pcapng/blocks/interface_description.rs
@@ -59,12 +59,12 @@ impl<'a> PcapNgBlock<'a> for InterfaceDescriptionBlock<'a> {
         Ok((slice, block))
     }
 
-    fn write_to<B: ByteOrder, W: Write>(&self, _state: &PcapNgState, writer: &mut W) -> IoResult<usize> {
+    fn write_to<B: ByteOrder, W: Write>(&self, state: &PcapNgState, writer: &mut W) -> IoResult<usize> {
         writer.write_u16::<B>(u32::from(self.linktype) as u16)?;
         writer.write_u16::<B>(0)?;
         writer.write_u32::<B>(self.snaplen)?;
 
-        let opt_len = InterfaceDescriptionOption::write_opts_to::<B, W>(&self.options, writer)?;
+        let opt_len = InterfaceDescriptionOption::write_opts_to::<B, W>(&self.options, state, None, writer)?;
         Ok(8 + opt_len)
     }
 
@@ -238,7 +238,7 @@ impl<'a> PcapNgOption<'a> for InterfaceDescriptionOption<'a> {
         Ok(opt)
     }
 
-    fn write_to<B: ByteOrder, W: Write>(&self, writer: &mut W) -> IoResult<usize> {
+    fn write_to<B: ByteOrder, W: Write>(&self, _state: &PcapNgState, _interface_id: Option<u32>, writer: &mut W) -> IoResult<usize> {
         match self {
             InterfaceDescriptionOption::Comment(a) => a.write_opt_to::<B, W>(1, writer),
             InterfaceDescriptionOption::IfName(a) => a.write_opt_to::<B, W>(2, writer),

--- a/src/pcapng/blocks/interface_description.rs
+++ b/src/pcapng/blocks/interface_description.rs
@@ -39,7 +39,7 @@ pub struct InterfaceDescriptionBlock<'a> {
 }
 
 impl<'a> PcapNgBlock<'a> for InterfaceDescriptionBlock<'a> {
-    fn from_slice<B: ByteOrder>(_state: &PcapNgState, mut slice: &'a [u8]) -> Result<(&'a [u8], Self), PcapError> {
+    fn from_slice<B: ByteOrder>(state: &PcapNgState, mut slice: &'a [u8]) -> Result<(&'a [u8], Self), PcapError> {
         if slice.len() < 8 {
             return Err(PcapError::InvalidField("InterfaceDescriptionBlock: block length < 8"));
         }
@@ -52,7 +52,7 @@ impl<'a> PcapNgBlock<'a> for InterfaceDescriptionBlock<'a> {
         }
 
         let snaplen = slice.read_u32::<B>().unwrap();
-        let (slice, options) = InterfaceDescriptionOption::opts_from_slice::<B>(slice)?;
+        let (slice, options) = InterfaceDescriptionOption::opts_from_slice::<B>(state, None, slice)?;
 
         let block = InterfaceDescriptionBlock { linktype, snaplen, options };
 
@@ -161,7 +161,7 @@ pub enum InterfaceDescriptionOption<'a> {
 }
 
 impl<'a> PcapNgOption<'a> for InterfaceDescriptionOption<'a> {
-    fn from_slice<B: ByteOrder>(code: u16, length: u16, mut slice: &'a [u8]) -> Result<Self, PcapError> {
+    fn from_slice<B: ByteOrder>(_state: &PcapNgState, _interface_id: Option<u32>, code: u16, length: u16, mut slice: &'a [u8]) -> Result<Self, PcapError> {
         let opt = match code {
             1 => InterfaceDescriptionOption::Comment(Cow::Borrowed(std::str::from_utf8(slice)?)),
             2 => InterfaceDescriptionOption::IfName(Cow::Borrowed(std::str::from_utf8(slice)?)),

--- a/src/pcapng/blocks/interface_description.rs
+++ b/src/pcapng/blocks/interface_description.rs
@@ -3,7 +3,7 @@
 //! Interface Description Block (IDB).
 
 use std::borrow::Cow;
-use std::io::{Result as IoResult, Write};
+use std::io::Write;
 
 use byteorder_slice::byteorder::WriteBytesExt;
 use byteorder_slice::result::ReadSlice;
@@ -59,7 +59,7 @@ impl<'a> PcapNgBlock<'a> for InterfaceDescriptionBlock<'a> {
         Ok((slice, block))
     }
 
-    fn write_to<B: ByteOrder, W: Write>(&self, state: &PcapNgState, writer: &mut W) -> IoResult<usize> {
+    fn write_to<B: ByteOrder, W: Write>(&self, state: &PcapNgState, writer: &mut W) -> Result<usize, PcapError> {
         writer.write_u16::<B>(u32::from(self.linktype) as u16)?;
         writer.write_u16::<B>(0)?;
         writer.write_u32::<B>(self.snaplen)?;
@@ -238,8 +238,8 @@ impl<'a> PcapNgOption<'a> for InterfaceDescriptionOption<'a> {
         Ok(opt)
     }
 
-    fn write_to<B: ByteOrder, W: Write>(&self, _state: &PcapNgState, _interface_id: Option<u32>, writer: &mut W) -> IoResult<usize> {
-        match self {
+    fn write_to<B: ByteOrder, W: Write>(&self, _state: &PcapNgState, _interface_id: Option<u32>, writer: &mut W) -> Result<usize, PcapError> {
+        Ok(match self {
             InterfaceDescriptionOption::Comment(a) => a.write_opt_to::<B, W>(1, writer),
             InterfaceDescriptionOption::IfName(a) => a.write_opt_to::<B, W>(2, writer),
             InterfaceDescriptionOption::IfDescription(a) => a.write_opt_to::<B, W>(3, writer),
@@ -258,7 +258,7 @@ impl<'a> PcapNgOption<'a> for InterfaceDescriptionOption<'a> {
             InterfaceDescriptionOption::CustomBinary(a) => a.write_opt_to::<B, W>(a.code, writer),
             InterfaceDescriptionOption::CustomUtf8(a) => a.write_opt_to::<B, W>(a.code, writer),
             InterfaceDescriptionOption::Unknown(a) => a.write_opt_to::<B, W>(a.code, writer),
-        }
+        }?)
     }
 }
 

--- a/src/pcapng/blocks/interface_description.rs
+++ b/src/pcapng/blocks/interface_description.rs
@@ -4,6 +4,7 @@
 
 use std::borrow::Cow;
 use std::io::Write;
+use std::time::Duration;
 
 use byteorder_slice::byteorder::WriteBytesExt;
 use byteorder_slice::result::ReadSlice;
@@ -92,6 +93,17 @@ impl<'a> InterfaceDescriptionBlock<'a> {
         }
 
         ts_resol
+    }
+
+    /// Returns the timestamp offset of the interface, or zero if it has none.
+    pub fn ts_offset(&self) -> Duration {
+        for opt in &self.options {
+            if let InterfaceDescriptionOption::IfTsOffset(offset) = opt {
+                return Duration::from_secs(*offset)
+            }
+        }
+
+        Duration::ZERO
     }
 }
 

--- a/src/pcapng/blocks/interface_description.rs
+++ b/src/pcapng/blocks/interface_description.rs
@@ -14,6 +14,7 @@ use once_cell::sync::Lazy;
 use super::block_common::{Block, PcapNgBlock};
 use super::opt_common::{CustomBinaryOption, CustomUtf8Option, PcapNgOption, UnknownOption, WriteOptTo};
 use crate::errors::PcapError;
+use crate::pcapng::PcapNgState;
 use crate::DataLink;
 
 
@@ -38,7 +39,7 @@ pub struct InterfaceDescriptionBlock<'a> {
 }
 
 impl<'a> PcapNgBlock<'a> for InterfaceDescriptionBlock<'a> {
-    fn from_slice<B: ByteOrder>(mut slice: &'a [u8]) -> Result<(&'a [u8], Self), PcapError> {
+    fn from_slice<B: ByteOrder>(_state: &PcapNgState, mut slice: &'a [u8]) -> Result<(&'a [u8], Self), PcapError> {
         if slice.len() < 8 {
             return Err(PcapError::InvalidField("InterfaceDescriptionBlock: block length < 8"));
         }
@@ -58,7 +59,7 @@ impl<'a> PcapNgBlock<'a> for InterfaceDescriptionBlock<'a> {
         Ok((slice, block))
     }
 
-    fn write_to<B: ByteOrder, W: Write>(&self, writer: &mut W) -> IoResult<usize> {
+    fn write_to<B: ByteOrder, W: Write>(&self, _state: &PcapNgState, writer: &mut W) -> IoResult<usize> {
         writer.write_u16::<B>(u32::from(self.linktype) as u16)?;
         writer.write_u16::<B>(0)?;
         writer.write_u32::<B>(self.snaplen)?;

--- a/src/pcapng/blocks/interface_statistics.rs
+++ b/src/pcapng/blocks/interface_statistics.rs
@@ -1,7 +1,7 @@
 //! Interface Statistics Block.
 
 use std::borrow::Cow;
-use std::io::{Result as IoResult, Write};
+use std::io::Write;
 use std::time::Duration;
 
 use byteorder_slice::byteorder::WriteBytesExt;
@@ -46,7 +46,7 @@ impl<'a> PcapNgBlock<'a> for InterfaceStatisticsBlock<'a> {
         Ok((slice, block))
     }
 
-    fn write_to<B: ByteOrder, W: Write>(&self, state: &PcapNgState, writer: &mut W) -> IoResult<usize> {
+    fn write_to<B: ByteOrder, W: Write>(&self, state: &PcapNgState, writer: &mut W) -> Result<usize, PcapError> {
         writer.write_u32::<B>(self.interface_id)?;
         state.encode_timestamp::<B, W>(self.interface_id, self.timestamp, writer)?;
 
@@ -128,8 +128,8 @@ impl<'a> PcapNgOption<'a> for InterfaceStatisticsOption<'a> {
         Ok(opt)
     }
 
-    fn write_to<B: ByteOrder, W: Write>(&self, state: &PcapNgState, interface_id: Option<u32>, writer: &mut W) -> IoResult<usize> {
-        match self {
+    fn write_to<B: ByteOrder, W: Write>(&self, state: &PcapNgState, interface_id: Option<u32>, writer: &mut W) -> Result<usize, PcapError> {
+        Ok(match self {
             InterfaceStatisticsOption::Comment(a) => a.write_opt_to::<B, W>(1, writer),
             InterfaceStatisticsOption::IsbStartTime(timestamp) => {
                 writer.write_u16::<B>(2)?;
@@ -151,6 +151,6 @@ impl<'a> PcapNgOption<'a> for InterfaceStatisticsOption<'a> {
             InterfaceStatisticsOption::CustomBinary(a) => a.write_opt_to::<B, W>(a.code, writer),
             InterfaceStatisticsOption::CustomUtf8(a) => a.write_opt_to::<B, W>(a.code, writer),
             InterfaceStatisticsOption::Unknown(a) => a.write_opt_to::<B, W>(a.code, writer),
-        }
+        }?)
     }
 }

--- a/src/pcapng/blocks/interface_statistics.rs
+++ b/src/pcapng/blocks/interface_statistics.rs
@@ -50,7 +50,7 @@ impl<'a> PcapNgBlock<'a> for InterfaceStatisticsBlock<'a> {
         writer.write_u32::<B>(self.interface_id)?;
         state.encode_timestamp::<B, W>(self.interface_id, self.timestamp, writer)?;
 
-        let opt_len = InterfaceStatisticsOption::write_opts_to::<B, _>(&self.options, writer)?;
+        let opt_len = InterfaceStatisticsOption::write_opts_to::<B, _>(&self.options, state, Some(self.interface_id), writer)?;
         Ok(12 + opt_len)
     }
 
@@ -124,7 +124,7 @@ impl<'a> PcapNgOption<'a> for InterfaceStatisticsOption<'a> {
         Ok(opt)
     }
 
-    fn write_to<B: ByteOrder, W: Write>(&self, writer: &mut W) -> IoResult<usize> {
+    fn write_to<B: ByteOrder, W: Write>(&self, _state: &PcapNgState, _interface_id: Option<u32>, writer: &mut W) -> IoResult<usize> {
         match self {
             InterfaceStatisticsOption::Comment(a) => a.write_opt_to::<B, W>(1, writer),
             InterfaceStatisticsOption::IsbStartTime(a) => a.write_opt_to::<B, W>(2, writer),

--- a/src/pcapng/blocks/interface_statistics.rs
+++ b/src/pcapng/blocks/interface_statistics.rs
@@ -39,7 +39,7 @@ impl<'a> PcapNgBlock<'a> for InterfaceStatisticsBlock<'a> {
 
         let interface_id = slice.read_u32::<B>().unwrap();
         let timestamp = state.decode_timestamp::<B>(interface_id, &mut slice)?;
-        let (slice, options) = InterfaceStatisticsOption::opts_from_slice::<B>(slice)?;
+        let (slice, options) = InterfaceStatisticsOption::opts_from_slice::<B>(state, Some(interface_id), slice)?;
 
         let block = InterfaceStatisticsBlock { interface_id, timestamp, options };
 
@@ -104,7 +104,7 @@ pub enum InterfaceStatisticsOption<'a> {
 }
 
 impl<'a> PcapNgOption<'a> for InterfaceStatisticsOption<'a> {
-    fn from_slice<B: ByteOrder>(code: u16, length: u16, mut slice: &'a [u8]) -> Result<Self, PcapError> {
+    fn from_slice<B: ByteOrder>(_state: &PcapNgState, _interface_id: Option<u32>, code: u16, length: u16, mut slice: &'a [u8]) -> Result<Self, PcapError> {
         let opt = match code {
             1 => InterfaceStatisticsOption::Comment(Cow::Borrowed(std::str::from_utf8(slice)?)),
             2 => InterfaceStatisticsOption::IsbStartTime(slice.read_u64::<B>().map_err(|_| PcapError::IncompleteBuffer)?),

--- a/src/pcapng/blocks/interface_statistics.rs
+++ b/src/pcapng/blocks/interface_statistics.rs
@@ -11,6 +11,7 @@ use derive_into_owned::IntoOwned;
 use super::block_common::{Block, PcapNgBlock};
 use super::opt_common::{CustomBinaryOption, CustomUtf8Option, PcapNgOption, UnknownOption, WriteOptTo};
 use crate::errors::PcapError;
+use crate::pcapng::PcapNgState;
 
 
 /// The Interface Statistics Block contains the capture statistics for a given interface and it is optional.
@@ -33,7 +34,7 @@ pub struct InterfaceStatisticsBlock<'a> {
 }
 
 impl<'a> PcapNgBlock<'a> for InterfaceStatisticsBlock<'a> {
-    fn from_slice<B: ByteOrder>(mut slice: &'a [u8]) -> Result<(&[u8], Self), PcapError> {
+    fn from_slice<B: ByteOrder>(_state: &PcapNgState, mut slice: &'a [u8]) -> Result<(&'a [u8], Self), PcapError> {
         if slice.len() < 12 {
             return Err(PcapError::InvalidField("InterfaceStatisticsBlock: block length < 12"));
         }
@@ -47,7 +48,7 @@ impl<'a> PcapNgBlock<'a> for InterfaceStatisticsBlock<'a> {
         Ok((slice, block))
     }
 
-    fn write_to<B: ByteOrder, W: Write>(&self, writer: &mut W) -> IoResult<usize> {
+    fn write_to<B: ByteOrder, W: Write>(&self, _state: &PcapNgState, writer: &mut W) -> IoResult<usize> {
         writer.write_u32::<B>(self.interface_id)?;
         writer.write_u64::<B>(self.timestamp)?;
 

--- a/src/pcapng/blocks/name_resolution.rs
+++ b/src/pcapng/blocks/name_resolution.rs
@@ -45,7 +45,7 @@ impl<'a> PcapNgBlock<'a> for NameResolutionBlock<'a> {
         Ok((rem, block))
     }
 
-    fn write_to<B: ByteOrder, W: Write>(&self, state: &PcapNgState, writer: &mut W) -> IoResult<usize> {
+    fn write_to<B: ByteOrder, W: Write>(&self, state: &PcapNgState, writer: &mut W) -> Result<usize, PcapError> {
         let mut len = 0;
 
         for record in &self.records {
@@ -346,8 +346,8 @@ impl<'a> PcapNgOption<'a> for NameResolutionOption<'a> {
         Ok(opt)
     }
 
-    fn write_to<B: ByteOrder, W: Write>(&self, _state: &PcapNgState, _interface_id: Option<u32>, writer: &mut W) -> IoResult<usize> {
-        match self {
+    fn write_to<B: ByteOrder, W: Write>(&self, _state: &PcapNgState, _interface_id: Option<u32>, writer: &mut W) -> Result<usize, PcapError> {
+        Ok(match self {
             NameResolutionOption::Comment(a) => a.write_opt_to::<B, W>(1, writer),
             NameResolutionOption::NsDnsName(a) => a.write_opt_to::<B, W>(2, writer),
             NameResolutionOption::NsDnsIpv4Addr(a) => a.write_opt_to::<B, W>(3, writer),
@@ -355,6 +355,6 @@ impl<'a> PcapNgOption<'a> for NameResolutionOption<'a> {
             NameResolutionOption::CustomBinary(a) => a.write_opt_to::<B, W>(a.code, writer),
             NameResolutionOption::CustomUtf8(a) => a.write_opt_to::<B, W>(a.code, writer),
             NameResolutionOption::Unknown(a) => a.write_opt_to::<B, W>(a.code, writer),
-        }
+        }?)
     }
 }

--- a/src/pcapng/blocks/name_resolution.rs
+++ b/src/pcapng/blocks/name_resolution.rs
@@ -25,7 +25,7 @@ pub struct NameResolutionBlock<'a> {
 }
 
 impl<'a> PcapNgBlock<'a> for NameResolutionBlock<'a> {
-    fn from_slice<B: ByteOrder>(_state: &PcapNgState, mut slice: &'a [u8]) -> Result<(&'a [u8], Self), PcapError> {
+    fn from_slice<B: ByteOrder>(state: &PcapNgState, mut slice: &'a [u8]) -> Result<(&'a [u8], Self), PcapError> {
         let mut records = Vec::new();
 
         loop {
@@ -38,7 +38,7 @@ impl<'a> PcapNgBlock<'a> for NameResolutionBlock<'a> {
             }
         }
 
-        let (rem, options) = NameResolutionOption::opts_from_slice::<B>(slice)?;
+        let (rem, options) = NameResolutionOption::opts_from_slice::<B>(state, None, slice)?;
 
         let block = NameResolutionBlock { records, options };
 
@@ -320,7 +320,7 @@ pub enum NameResolutionOption<'a> {
 }
 
 impl<'a> PcapNgOption<'a> for NameResolutionOption<'a> {
-    fn from_slice<B: ByteOrder>(code: u16, length: u16, slice: &'a [u8]) -> Result<Self, PcapError> {
+    fn from_slice<B: ByteOrder>(_state: &PcapNgState, _interface_id: Option<u32>, code: u16, length: u16, slice: &'a [u8]) -> Result<Self, PcapError> {
         let opt = match code {
             1 => NameResolutionOption::Comment(Cow::Borrowed(std::str::from_utf8(slice)?)),
             2 => NameResolutionOption::NsDnsName(Cow::Borrowed(std::str::from_utf8(slice)?)),

--- a/src/pcapng/blocks/name_resolution.rs
+++ b/src/pcapng/blocks/name_resolution.rs
@@ -45,7 +45,7 @@ impl<'a> PcapNgBlock<'a> for NameResolutionBlock<'a> {
         Ok((rem, block))
     }
 
-    fn write_to<B: ByteOrder, W: Write>(&self, _state: &PcapNgState, writer: &mut W) -> IoResult<usize> {
+    fn write_to<B: ByteOrder, W: Write>(&self, state: &PcapNgState, writer: &mut W) -> IoResult<usize> {
         let mut len = 0;
 
         for record in &self.records {
@@ -53,7 +53,7 @@ impl<'a> PcapNgBlock<'a> for NameResolutionBlock<'a> {
         }
         len += Record::End.write_to::<B, _>(writer)?;
 
-        len += NameResolutionOption::write_opts_to::<B, _>(&self.options, writer)?;
+        len += NameResolutionOption::write_opts_to::<B, _>(&self.options, state, None, writer)?;
 
         Ok(len)
     }
@@ -346,7 +346,7 @@ impl<'a> PcapNgOption<'a> for NameResolutionOption<'a> {
         Ok(opt)
     }
 
-    fn write_to<B: ByteOrder, W: Write>(&self, writer: &mut W) -> IoResult<usize> {
+    fn write_to<B: ByteOrder, W: Write>(&self, _state: &PcapNgState, _interface_id: Option<u32>, writer: &mut W) -> IoResult<usize> {
         match self {
             NameResolutionOption::Comment(a) => a.write_opt_to::<B, W>(1, writer),
             NameResolutionOption::NsDnsName(a) => a.write_opt_to::<B, W>(2, writer),

--- a/src/pcapng/blocks/name_resolution.rs
+++ b/src/pcapng/blocks/name_resolution.rs
@@ -11,6 +11,7 @@ use derive_into_owned::IntoOwned;
 use super::block_common::{Block, PcapNgBlock};
 use super::opt_common::{CustomBinaryOption, CustomUtf8Option, PcapNgOption, UnknownOption, WriteOptTo};
 use crate::errors::PcapError;
+use crate::pcapng::PcapNgState;
 
 
 /// The Name Resolution Block (NRB) is used to support the correlation of numeric addresses
@@ -24,7 +25,7 @@ pub struct NameResolutionBlock<'a> {
 }
 
 impl<'a> PcapNgBlock<'a> for NameResolutionBlock<'a> {
-    fn from_slice<B: ByteOrder>(mut slice: &'a [u8]) -> Result<(&'a [u8], Self), PcapError> {
+    fn from_slice<B: ByteOrder>(_state: &PcapNgState, mut slice: &'a [u8]) -> Result<(&'a [u8], Self), PcapError> {
         let mut records = Vec::new();
 
         loop {
@@ -44,7 +45,7 @@ impl<'a> PcapNgBlock<'a> for NameResolutionBlock<'a> {
         Ok((rem, block))
     }
 
-    fn write_to<B: ByteOrder, W: Write>(&self, writer: &mut W) -> IoResult<usize> {
+    fn write_to<B: ByteOrder, W: Write>(&self, _state: &PcapNgState, writer: &mut W) -> IoResult<usize> {
         let mut len = 0;
 
         for record in &self.records {

--- a/src/pcapng/blocks/opt_common.rs
+++ b/src/pcapng/blocks/opt_common.rs
@@ -59,17 +59,17 @@ pub(crate) trait PcapNgOption<'a> {
     }
 
     /// Write the option to a writer
-    fn write_to<B: ByteOrder, W: Write>(&self, writer: &mut W) -> IoResult<usize>;
+    fn write_to<B: ByteOrder, W: Write>(&self, state: &PcapNgState, interface_id: Option<u32>, writer: &mut W) -> IoResult<usize>;
 
     /// Write all options in a block
-    fn write_opts_to<B: ByteOrder, W: Write>(opts: &[Self], writer: &mut W) -> IoResult<usize>
+    fn write_opts_to<B: ByteOrder, W: Write>(opts: &[Self], state: &PcapNgState, interface_id: Option<u32>, writer: &mut W) -> IoResult<usize>
     where
         Self: std::marker::Sized,
     {
         let mut have_opt = false;
         let mut written = 0;
         for opt in opts {
-            written += opt.write_to::<B, W>(writer)?;
+            written += opt.write_to::<B, W>(state, interface_id, writer)?;
             have_opt = true;
         }
 

--- a/src/pcapng/blocks/opt_common.rs
+++ b/src/pcapng/blocks/opt_common.rs
@@ -59,10 +59,10 @@ pub(crate) trait PcapNgOption<'a> {
     }
 
     /// Write the option to a writer
-    fn write_to<B: ByteOrder, W: Write>(&self, state: &PcapNgState, interface_id: Option<u32>, writer: &mut W) -> IoResult<usize>;
+    fn write_to<B: ByteOrder, W: Write>(&self, state: &PcapNgState, interface_id: Option<u32>, writer: &mut W) -> Result<usize, PcapError>;
 
     /// Write all options in a block
-    fn write_opts_to<B: ByteOrder, W: Write>(opts: &[Self], state: &PcapNgState, interface_id: Option<u32>, writer: &mut W) -> IoResult<usize>
+    fn write_opts_to<B: ByteOrder, W: Write>(opts: &[Self], state: &PcapNgState, interface_id: Option<u32>, writer: &mut W) -> Result<usize, PcapError>
     where
         Self: std::marker::Sized,
     {

--- a/src/pcapng/blocks/opt_common.rs
+++ b/src/pcapng/blocks/opt_common.rs
@@ -7,17 +7,18 @@ use byteorder_slice::ByteOrder;
 use derive_into_owned::IntoOwned;
 
 use crate::errors::PcapError;
+use crate::pcapng::PcapNgState;
 
 
 /// Common fonctions of the PcapNg options
 pub(crate) trait PcapNgOption<'a> {
     /// Parse an option from a slice
-    fn from_slice<B: ByteOrder>(code: u16, length: u16, slice: &'a [u8]) -> Result<Self, PcapError>
+    fn from_slice<B: ByteOrder>(state: &PcapNgState, interface_id: Option<u32>, code: u16, length: u16, slice: &'a [u8]) -> Result<Self, PcapError>
     where
         Self: std::marker::Sized;
 
     /// Parse all options in a block
-    fn opts_from_slice<B: ByteOrder>(mut slice: &'a [u8]) -> Result<(&'a [u8], Vec<Self>), PcapError>
+    fn opts_from_slice<B: ByteOrder>(state: &PcapNgState, interface_id: Option<u32>, mut slice: &'a [u8]) -> Result<(&'a [u8], Vec<Self>), PcapError>
     where
         Self: std::marker::Sized,
     {
@@ -46,7 +47,7 @@ pub(crate) trait PcapNgOption<'a> {
             }
 
             let tmp_slice = &slice[..length];
-            let opt = Self::from_slice::<B>(code, length as u16, tmp_slice)?;
+            let opt = Self::from_slice::<B>(state, interface_id, code, length as u16, tmp_slice)?;
 
             // Jump over the padding
             slice = &slice[length + pad_len..];

--- a/src/pcapng/blocks/packet.rs
+++ b/src/pcapng/blocks/packet.rs
@@ -1,7 +1,7 @@
 //! Packet Block.
 
 use std::borrow::Cow;
-use std::io::{Result as IoResult, Write};
+use std::io::Write;
 use std::time::Duration;
 
 use byteorder_slice::byteorder::WriteBytesExt;
@@ -79,7 +79,7 @@ impl<'a> PcapNgBlock<'a> for PacketBlock<'a> {
         Ok((slice, block))
     }
 
-    fn write_to<B: ByteOrder, W: Write>(&self, state: &PcapNgState, writer: &mut W) -> IoResult<usize> {
+    fn write_to<B: ByteOrder, W: Write>(&self, state: &PcapNgState, writer: &mut W) -> Result<usize, PcapError> {
         writer.write_u16::<B>(self.interface_id)?;
         writer.write_u16::<B>(self.drop_count)?;
         state.encode_timestamp::<B, W>(self.interface_id as u32, self.timestamp, writer)?;
@@ -143,14 +143,14 @@ impl<'a> PcapNgOption<'a> for PacketOption<'a> {
         Ok(opt)
     }
 
-    fn write_to<B: ByteOrder, W: Write>(&self, _state: &PcapNgState, _interface_id: Option<u32>, writer: &mut W) -> IoResult<usize> {
-        match self {
+    fn write_to<B: ByteOrder, W: Write>(&self, _state: &PcapNgState, _interface_id: Option<u32>, writer: &mut W) -> Result<usize, PcapError> {
+        Ok(match self {
             PacketOption::Comment(a) => a.write_opt_to::<B, W>(1, writer),
             PacketOption::Flags(a) => a.write_opt_to::<B, W>(2, writer),
             PacketOption::Hash(a) => a.write_opt_to::<B, W>(3, writer),
             PacketOption::CustomBinary(a) => a.write_opt_to::<B, W>(a.code, writer),
             PacketOption::CustomUtf8(a) => a.write_opt_to::<B, W>(a.code, writer),
             PacketOption::Unknown(a) => a.write_opt_to::<B, W>(a.code, writer),
-        }
+        }?)
     }
 }

--- a/src/pcapng/blocks/packet.rs
+++ b/src/pcapng/blocks/packet.rs
@@ -11,6 +11,7 @@ use derive_into_owned::IntoOwned;
 use super::block_common::{Block, PcapNgBlock};
 use super::opt_common::{CustomBinaryOption, CustomUtf8Option, PcapNgOption, UnknownOption, WriteOptTo};
 use crate::errors::PcapError;
+use crate::pcapng::PcapNgState;
 
 /// The Packet Block is obsolete, and MUST NOT be used in new files.
 /// Use the Enhanced Packet Block or Simple Packet Block instead.
@@ -43,7 +44,7 @@ pub struct PacketBlock<'a> {
 }
 
 impl<'a> PcapNgBlock<'a> for PacketBlock<'a> {
-    fn from_slice<B: ByteOrder>(mut slice: &'a [u8]) -> Result<(&'a [u8], Self), PcapError> {
+    fn from_slice<B: ByteOrder>(_state: &PcapNgState, mut slice: &'a [u8]) -> Result<(&'a [u8], Self), PcapError> {
         if slice.len() < 20 {
             return Err(PcapError::InvalidField("EnhancedPacketBlock: block length length < 20"));
         }
@@ -78,7 +79,7 @@ impl<'a> PcapNgBlock<'a> for PacketBlock<'a> {
         Ok((slice, block))
     }
 
-    fn write_to<B: ByteOrder, W: Write>(&self, writer: &mut W) -> IoResult<usize> {
+    fn write_to<B: ByteOrder, W: Write>(&self, _state: &PcapNgState, writer: &mut W) -> IoResult<usize> {
         writer.write_u16::<B>(self.interface_id)?;
         writer.write_u16::<B>(self.drop_count)?;
         writer.write_u64::<B>(self.timestamp)?;

--- a/src/pcapng/blocks/packet.rs
+++ b/src/pcapng/blocks/packet.rs
@@ -65,7 +65,7 @@ impl<'a> PcapNgBlock<'a> for PacketBlock<'a> {
         let data = &slice[..captured_len as usize];
         slice = &slice[tot_len..];
 
-        let (slice, options) = PacketOption::opts_from_slice::<B>(slice)?;
+        let (slice, options) = PacketOption::opts_from_slice::<B>(state, Some(interface_id as u32), slice)?;
         let block = PacketBlock {
             interface_id,
             drop_count,
@@ -123,7 +123,7 @@ pub enum PacketOption<'a> {
 }
 
 impl<'a> PcapNgOption<'a> for PacketOption<'a> {
-    fn from_slice<B: ByteOrder>(code: u16, length: u16, mut slice: &'a [u8]) -> Result<Self, PcapError> {
+    fn from_slice<B: ByteOrder>(_state: &PcapNgState, _interface_id: Option<u32>, code: u16, length: u16, mut slice: &'a [u8]) -> Result<Self, PcapError> {
         let opt = match code {
             1 => PacketOption::Comment(Cow::Borrowed(std::str::from_utf8(slice)?)),
             2 => {

--- a/src/pcapng/blocks/packet.rs
+++ b/src/pcapng/blocks/packet.rs
@@ -90,7 +90,7 @@ impl<'a> PcapNgBlock<'a> for PacketBlock<'a> {
         let pad_len = (4 - (self.captured_len as usize % 4)) % 4;
         writer.write_all(&[0_u8; 3][..pad_len])?;
 
-        let opt_len = PacketOption::write_opts_to::<B, _>(&self.options, writer)?;
+        let opt_len = PacketOption::write_opts_to::<B, _>(&self.options, state, Some(self.interface_id as u32), writer)?;
 
         Ok(20 + self.data.len() + pad_len + opt_len)
     }
@@ -143,7 +143,7 @@ impl<'a> PcapNgOption<'a> for PacketOption<'a> {
         Ok(opt)
     }
 
-    fn write_to<B: ByteOrder, W: Write>(&self, writer: &mut W) -> IoResult<usize> {
+    fn write_to<B: ByteOrder, W: Write>(&self, _state: &PcapNgState, _interface_id: Option<u32>, writer: &mut W) -> IoResult<usize> {
         match self {
             PacketOption::Comment(a) => a.write_opt_to::<B, W>(1, writer),
             PacketOption::Flags(a) => a.write_opt_to::<B, W>(2, writer),

--- a/src/pcapng/blocks/section_header.rs
+++ b/src/pcapng/blocks/section_header.rs
@@ -72,7 +72,7 @@ impl<'a> PcapNgBlock<'a> for SectionHeaderBlock<'a> {
         }
     }
 
-    fn write_to<B: ByteOrder, W: Write>(&self, _state: &PcapNgState, writer: &mut W) -> IoResult<usize> {
+    fn write_to<B: ByteOrder, W: Write>(&self, state: &PcapNgState, writer: &mut W) -> IoResult<usize> {
         match self.endianness {
             Endianness::Big => writer.write_u32::<BigEndian>(0x1A2B3C4D)?,
             Endianness::Little => writer.write_u32::<LittleEndian>(0x1A2B3C4D)?,
@@ -82,7 +82,7 @@ impl<'a> PcapNgBlock<'a> for SectionHeaderBlock<'a> {
         writer.write_u16::<B>(self.minor_version)?;
         writer.write_i64::<B>(self.section_length)?;
 
-        let opt_len = SectionHeaderOption::write_opts_to::<B, W>(&self.options, writer)?;
+        let opt_len = SectionHeaderOption::write_opts_to::<B, W>(&self.options, state, None, writer)?;
 
         Ok(16 + opt_len)
     }
@@ -147,7 +147,7 @@ impl<'a> PcapNgOption<'a> for SectionHeaderOption<'a> {
         Ok(opt)
     }
 
-    fn write_to<B: ByteOrder, W: Write>(&self, writer: &mut W) -> IoResult<usize> {
+    fn write_to<B: ByteOrder, W: Write>(&self, _state: &PcapNgState, _interface_id: Option<u32>, writer: &mut W) -> IoResult<usize> {
         match self {
             SectionHeaderOption::Comment(a) => a.write_opt_to::<B, W>(1, writer),
             SectionHeaderOption::Hardware(a) => a.write_opt_to::<B, W>(2, writer),

--- a/src/pcapng/blocks/section_header.rs
+++ b/src/pcapng/blocks/section_header.rs
@@ -11,6 +11,7 @@ use derive_into_owned::IntoOwned;
 use super::block_common::{Block, PcapNgBlock};
 use super::opt_common::{CustomBinaryOption, CustomUtf8Option, PcapNgOption, UnknownOption, WriteOptTo};
 use crate::errors::PcapError;
+use crate::pcapng::PcapNgState;
 use crate::Endianness;
 
 
@@ -39,7 +40,7 @@ pub struct SectionHeaderBlock<'a> {
 }
 
 impl<'a> PcapNgBlock<'a> for SectionHeaderBlock<'a> {
-    fn from_slice<B: ByteOrder>(mut slice: &'a [u8]) -> Result<(&'a [u8], Self), PcapError> {
+    fn from_slice<B: ByteOrder>(_state: &PcapNgState, mut slice: &'a [u8]) -> Result<(&'a [u8], Self), PcapError> {
         if slice.len() < 16 {
             return Err(PcapError::InvalidField("SectionHeaderBlock: block length < 16"));
         }
@@ -71,7 +72,7 @@ impl<'a> PcapNgBlock<'a> for SectionHeaderBlock<'a> {
         }
     }
 
-    fn write_to<B: ByteOrder, W: Write>(&self, writer: &mut W) -> IoResult<usize> {
+    fn write_to<B: ByteOrder, W: Write>(&self, _state: &PcapNgState, writer: &mut W) -> IoResult<usize> {
         match self.endianness {
             Endianness::Big => writer.write_u32::<BigEndian>(0x1A2B3C4D)?,
             Endianness::Little => writer.write_u32::<LittleEndian>(0x1A2B3C4D)?,

--- a/src/pcapng/blocks/section_header.rs
+++ b/src/pcapng/blocks/section_header.rs
@@ -1,7 +1,7 @@
 //! Section Header Block.
 
 use std::borrow::Cow;
-use std::io::{Result as IoResult, Write};
+use std::io::Write;
 
 use byteorder_slice::byteorder::WriteBytesExt;
 use byteorder_slice::result::ReadSlice;
@@ -72,7 +72,7 @@ impl<'a> PcapNgBlock<'a> for SectionHeaderBlock<'a> {
         }
     }
 
-    fn write_to<B: ByteOrder, W: Write>(&self, state: &PcapNgState, writer: &mut W) -> IoResult<usize> {
+    fn write_to<B: ByteOrder, W: Write>(&self, state: &PcapNgState, writer: &mut W) -> Result<usize, PcapError> {
         match self.endianness {
             Endianness::Big => writer.write_u32::<BigEndian>(0x1A2B3C4D)?,
             Endianness::Little => writer.write_u32::<LittleEndian>(0x1A2B3C4D)?,
@@ -147,8 +147,8 @@ impl<'a> PcapNgOption<'a> for SectionHeaderOption<'a> {
         Ok(opt)
     }
 
-    fn write_to<B: ByteOrder, W: Write>(&self, _state: &PcapNgState, _interface_id: Option<u32>, writer: &mut W) -> IoResult<usize> {
-        match self {
+    fn write_to<B: ByteOrder, W: Write>(&self, _state: &PcapNgState, _interface_id: Option<u32>, writer: &mut W) -> Result<usize, PcapError> {
+        Ok(match self {
             SectionHeaderOption::Comment(a) => a.write_opt_to::<B, W>(1, writer),
             SectionHeaderOption::Hardware(a) => a.write_opt_to::<B, W>(2, writer),
             SectionHeaderOption::OS(a) => a.write_opt_to::<B, W>(3, writer),
@@ -156,6 +156,6 @@ impl<'a> PcapNgOption<'a> for SectionHeaderOption<'a> {
             SectionHeaderOption::CustomBinary(a) => a.write_opt_to::<B, W>(a.code, writer),
             SectionHeaderOption::CustomUtf8(a) => a.write_opt_to::<B, W>(a.code, writer),
             SectionHeaderOption::Unknown(a) => a.write_opt_to::<B, W>(a.code, writer),
-        }
+        }?)
     }
 }

--- a/src/pcapng/blocks/simple_packet.rs
+++ b/src/pcapng/blocks/simple_packet.rs
@@ -10,6 +10,7 @@ use derive_into_owned::IntoOwned;
 
 use super::block_common::{Block, PcapNgBlock};
 use crate::errors::PcapError;
+use crate::pcapng::PcapNgState;
 
 
 /// The Simple Packet Block (SPB) is a lightweight container for storing the packets coming from the network.
@@ -25,7 +26,7 @@ pub struct SimplePacketBlock<'a> {
 }
 
 impl<'a> PcapNgBlock<'a> for SimplePacketBlock<'a> {
-    fn from_slice<B: ByteOrder>(mut slice: &'a [u8]) -> Result<(&'a [u8], Self), PcapError> {
+    fn from_slice<B: ByteOrder>(_state: &PcapNgState, mut slice: &'a [u8]) -> Result<(&'a [u8], Self), PcapError> {
         if slice.len() < 4 {
             return Err(PcapError::InvalidField("SimplePacketBlock: block length < 4"));
         }
@@ -36,7 +37,7 @@ impl<'a> PcapNgBlock<'a> for SimplePacketBlock<'a> {
         Ok((&[], packet))
     }
 
-    fn write_to<B: ByteOrder, W: Write>(&self, writer: &mut W) -> IoResult<usize> {
+    fn write_to<B: ByteOrder, W: Write>(&self, _state: &PcapNgState, writer: &mut W) -> IoResult<usize> {
         writer.write_u32::<B>(self.original_len)?;
         writer.write_all(&self.data)?;
 

--- a/src/pcapng/blocks/simple_packet.rs
+++ b/src/pcapng/blocks/simple_packet.rs
@@ -1,7 +1,7 @@
 //! Simple Packet Block (SPB).
 
 use std::borrow::Cow;
-use std::io::{Result as IoResult, Write};
+use std::io::Write;
 
 use byteorder_slice::byteorder::WriteBytesExt;
 use byteorder_slice::result::ReadSlice;
@@ -37,7 +37,7 @@ impl<'a> PcapNgBlock<'a> for SimplePacketBlock<'a> {
         Ok((&[], packet))
     }
 
-    fn write_to<B: ByteOrder, W: Write>(&self, _state: &PcapNgState, writer: &mut W) -> IoResult<usize> {
+    fn write_to<B: ByteOrder, W: Write>(&self, _state: &PcapNgState, writer: &mut W) -> Result<usize, PcapError> {
         writer.write_u32::<B>(self.original_len)?;
         writer.write_all(&self.data)?;
 

--- a/src/pcapng/blocks/systemd_journal_export.rs
+++ b/src/pcapng/blocks/systemd_journal_export.rs
@@ -1,7 +1,7 @@
 //! Systemd Journal Export Block.
 
 use std::borrow::Cow;
-use std::io::{Result as IoResult, Write};
+use std::io::Write;
 
 use byteorder_slice::ByteOrder;
 use derive_into_owned::IntoOwned;
@@ -24,7 +24,7 @@ impl<'a> PcapNgBlock<'a> for SystemdJournalExportBlock<'a> {
         Ok((&[], packet))
     }
 
-    fn write_to<B: ByteOrder, W: Write>(&self, _state: &PcapNgState, writer: &mut W) -> IoResult<usize> {
+    fn write_to<B: ByteOrder, W: Write>(&self, _state: &PcapNgState, writer: &mut W) -> Result<usize, PcapError> {
         writer.write_all(&self.journal_entry)?;
 
         let pad_len = (4 - (self.journal_entry.len() % 4)) % 4;

--- a/src/pcapng/blocks/systemd_journal_export.rs
+++ b/src/pcapng/blocks/systemd_journal_export.rs
@@ -8,6 +8,7 @@ use derive_into_owned::IntoOwned;
 
 use super::block_common::{Block, PcapNgBlock};
 use crate::errors::PcapError;
+use crate::pcapng::PcapNgState;
 
 
 /// The Systemd Journal Export Block is a lightweight containter for systemd Journal Export Format entry data.
@@ -18,12 +19,12 @@ pub struct SystemdJournalExportBlock<'a> {
 }
 
 impl<'a> PcapNgBlock<'a> for SystemdJournalExportBlock<'a> {
-    fn from_slice<B: ByteOrder>(slice: &'a [u8]) -> Result<(&'a [u8], Self), PcapError> {
+    fn from_slice<B: ByteOrder>(_state: &PcapNgState, slice: &'a [u8]) -> Result<(&'a [u8], Self), PcapError> {
         let packet = SystemdJournalExportBlock { journal_entry: Cow::Borrowed(slice) };
         Ok((&[], packet))
     }
 
-    fn write_to<B: ByteOrder, W: Write>(&self, writer: &mut W) -> IoResult<usize> {
+    fn write_to<B: ByteOrder, W: Write>(&self, _state: &PcapNgState, writer: &mut W) -> IoResult<usize> {
         writer.write_all(&self.journal_entry)?;
 
         let pad_len = (4 - (self.journal_entry.len() % 4)) % 4;

--- a/src/pcapng/blocks/unknown.rs
+++ b/src/pcapng/blocks/unknown.rs
@@ -7,6 +7,7 @@ use byteorder_slice::ByteOrder;
 use derive_into_owned::IntoOwned;
 
 use super::block_common::{Block, PcapNgBlock};
+use crate::pcapng::PcapNgState;
 use crate::PcapError;
 
 
@@ -29,14 +30,14 @@ impl<'a> UnknownBlock<'a> {
 }
 
 impl<'a> PcapNgBlock<'a> for UnknownBlock<'a> {
-    fn from_slice<B: ByteOrder>(_slice: &'a [u8]) -> Result<(&[u8], Self), PcapError>
+    fn from_slice<B: ByteOrder>(_state: &PcapNgState, _slice: &'a [u8]) -> Result<(&'a [u8], Self), PcapError>
     where
         Self: Sized,
     {
         unimplemented!("UnkknownBlock::<as PcapNgBlock>::From_slice shouldn't be called")
     }
 
-    fn write_to<B: ByteOrder, W: Write>(&self, writer: &mut W) -> IoResult<usize> {
+    fn write_to<B: ByteOrder, W: Write>(&self, _state: &PcapNgState, writer: &mut W) -> IoResult<usize> {
         writer.write_all(&self.value)?;
         Ok(self.value.len())
     }

--- a/src/pcapng/blocks/unknown.rs
+++ b/src/pcapng/blocks/unknown.rs
@@ -1,7 +1,7 @@
 //! Unknown Block.
 
 use std::borrow::Cow;
-use std::io::{Result as IoResult, Write};
+use std::io::Write;
 
 use byteorder_slice::ByteOrder;
 use derive_into_owned::IntoOwned;
@@ -37,7 +37,7 @@ impl<'a> PcapNgBlock<'a> for UnknownBlock<'a> {
         unimplemented!("UnkknownBlock::<as PcapNgBlock>::From_slice shouldn't be called")
     }
 
-    fn write_to<B: ByteOrder, W: Write>(&self, _state: &PcapNgState, writer: &mut W) -> IoResult<usize> {
+    fn write_to<B: ByteOrder, W: Write>(&self, _state: &PcapNgState, writer: &mut W) -> Result<usize, PcapError> {
         writer.write_all(&self.value)?;
         Ok(self.value.len())
     }

--- a/src/pcapng/mod.rs
+++ b/src/pcapng/mod.rs
@@ -3,6 +3,9 @@
 pub mod blocks;
 pub use blocks::{Block, PcapNgBlock, RawBlock};
 
+pub(crate) mod state;
+pub use state::PcapNgState;
+
 pub(crate) mod parser;
 pub use parser::*;
 

--- a/src/pcapng/parser.rs
+++ b/src/pcapng/parser.rs
@@ -1,10 +1,10 @@
 use byteorder_slice::{BigEndian, ByteOrder, LittleEndian};
 
+use super::PcapNgState;
 use super::blocks::block_common::{Block, RawBlock};
 use super::blocks::enhanced_packet::EnhancedPacketBlock;
-use super::blocks::interface_description::{InterfaceDescriptionBlock, TsResolution};
+use super::blocks::interface_description::InterfaceDescriptionBlock;
 use super::blocks::section_header::SectionHeaderBlock;
-use super::blocks::{INTERFACE_DESCRIPTION_BLOCK, SECTION_HEADER_BLOCK};
 use crate::errors::PcapError;
 use crate::Endianness;
 
@@ -44,12 +44,8 @@ use crate::Endianness;
 /// }
 /// ```
 pub struct PcapNgParser {
-    /// Current section of the pcapng
-    section: SectionHeaderBlock<'static>,
-    /// List of the interfaces of the current section of the pcapng
-    interfaces: Vec<InterfaceDescriptionBlock<'static>>,
-    /// Timestamp resolutions corresponding to the interfaces
-    ts_resolutions: Vec<TsResolution>,
+    /// Current state of the pcapng format.
+    state: PcapNgState,
 }
 
 impl PcapNgParser {
@@ -64,7 +60,13 @@ impl PcapNgParser {
             _ => return Err(PcapError::InvalidField("PcapNg: SectionHeader invalid or missing")),
         };
 
-        let parser = PcapNgParser { section, interfaces: Vec::new(), ts_resolutions: Vec::new() };
+        let state = PcapNgState {
+            section,
+            interfaces: Vec::new(),
+            ts_resolutions: Vec::new(),
+        };
+
+        let parser = PcapNgParser { state };
 
         Ok((rem, parser))
     }
@@ -72,7 +74,7 @@ impl PcapNgParser {
     /// Returns the remainder and the next [`Block`].
     pub fn next_block<'a>(&mut self, src: &'a [u8]) -> Result<(&'a [u8], Block<'a>), PcapError> {
         // Read next Block
-        let mut res = match self.section.endianness {
+        let mut res = match self.state.section.endianness {
             Endianness::Big => {
                 let (rem, raw_block) = self.next_raw_block_inner::<BigEndian>(src)?;
                 let block = raw_block.try_into_block::<BigEndian>()?;
@@ -88,6 +90,7 @@ impl PcapNgParser {
         // If the block is an EnhancedPacketBlock, adjust its timestamp with the correct TsResolution
         if let Ok((_, Block::EnhancedPacket(ref mut blk))) = &mut res {
             let ts_resol = self
+                .state
                 .ts_resolutions
                 .get(blk.interface_id as usize)
                 .ok_or(PcapError::InvalidInterfaceId(blk.interface_id))?;
@@ -101,7 +104,7 @@ impl PcapNgParser {
     /// Returns the remainder and the next [`RawBlock`].
     pub fn next_raw_block<'a>(&mut self, src: &'a [u8]) -> Result<(&'a [u8], RawBlock<'a>), PcapError> {
         // Read next Block
-        match self.section.endianness {
+        match self.state.section.endianness {
             Endianness::Big => self.next_raw_block_inner::<BigEndian>(src),
             Endianness::Little => self.next_raw_block_inner::<LittleEndian>(src),
         }
@@ -110,38 +113,22 @@ impl PcapNgParser {
     /// Inner function to parse the next raw block.
     fn next_raw_block_inner<'a, B: ByteOrder>(&mut self, src: &'a [u8]) -> Result<(&'a [u8], RawBlock<'a>), PcapError> {
         let (rem, raw_block) = RawBlock::from_slice::<B>(src)?;
-
-        match raw_block.type_ {
-            SECTION_HEADER_BLOCK => {
-                self.section = raw_block.clone().try_into_block::<B>()?.into_owned().into_section_header().unwrap();
-                self.interfaces.clear();
-                self.ts_resolutions.clear();
-            },
-            INTERFACE_DESCRIPTION_BLOCK => {
-                let interface = raw_block.clone().try_into_block::<B>()?.into_owned().into_interface_description().unwrap();
-                let ts_resolution = interface.ts_resolution()?;
-
-                self.interfaces.push(interface);
-                self.ts_resolutions.push(ts_resolution);
-            },
-            _ => {},
-        }
-
+        self.state.update_from_raw_block::<B>(&raw_block)?;
         Ok((rem, raw_block))
     }
 
     /// Returns the current [`SectionHeaderBlock`].
     pub fn section(&self) -> &SectionHeaderBlock<'static> {
-        &self.section
+        &self.state.section
     }
 
     /// Returns all the current [`InterfaceDescriptionBlock`].
     pub fn interfaces(&self) -> &[InterfaceDescriptionBlock<'static>] {
-        &self.interfaces[..]
+        &self.state.interfaces[..]
     }
 
     /// Returns the [`InterfaceDescriptionBlock`] corresponding to the given packet.
     pub fn packet_interface(&self, packet: &EnhancedPacketBlock) -> Option<&InterfaceDescriptionBlock> {
-        self.interfaces.get(packet.interface_id as usize)
+        self.state.interfaces.get(packet.interface_id as usize)
     }
 }

--- a/src/pcapng/state.rs
+++ b/src/pcapng/state.rs
@@ -1,0 +1,68 @@
+use byteorder_slice::ByteOrder;
+
+use super::blocks::block_common::{Block, RawBlock};
+use super::blocks::interface_description::{InterfaceDescriptionBlock, TsResolution};
+use super::blocks::section_header::SectionHeaderBlock;
+use super::blocks::{INTERFACE_DESCRIPTION_BLOCK, SECTION_HEADER_BLOCK};
+use crate::errors::PcapError;
+
+#[cfg(doc)]
+use {
+    super::blocks::interface_description::InterfaceDescriptionOption,
+    crate::pcapng::{PcapNgReader, PcapNgWriter},
+    crate::Endianness,
+};
+
+/// State that must be maintained whilst reading or writing a PcapNg stream.
+///
+/// This state is necessary because the encoding of blocks depends on
+/// information seen earlier in the stream, such as the [`Endianness`] of the
+/// [`SectionHeaderBlock`] and the [`TsResolution`] of each
+/// [`InterfaceDescriptionBlock`].
+///
+/// Normally this state is maintained internally by a [`PcapNgReader`] or
+/// [`PcapNgWriter`], but it's also possible to create a new [`PcapNgState`]
+/// with [`PcapNgState::default`], and then update it by calling
+/// [`PcapNgState::update_from_block`] or [`PcapNgState::update_from_raw_block`].
+///
+#[derive(Debug, Default)]
+pub struct PcapNgState {
+    /// Current section of the pcapng
+    pub(crate) section: SectionHeaderBlock<'static>,
+    /// List of the interfaces of the current section of the pcapng
+    pub(crate) interfaces: Vec<InterfaceDescriptionBlock<'static>>,
+    /// Timestamp resolutions corresponding to the interfaces
+    pub(crate) ts_resolutions: Vec<TsResolution>,
+}
+
+impl PcapNgState {
+    /// Update the state based on the next [`Block`].
+    pub fn update_from_block(&mut self, block: &Block) -> Result<(), PcapError> {
+        match block {
+            Block::SectionHeader(blk) => {
+                self.section = blk.clone().into_owned();
+                self.interfaces.clear();
+                self.ts_resolutions.clear();
+            },
+            Block::InterfaceDescription(blk) => {
+                let ts_resolution = blk.ts_resolution()?;
+                self.ts_resolutions.push(ts_resolution);
+
+                self.interfaces.push(blk.clone().into_owned());
+            },
+            _ => {},
+        }
+        Ok(())
+    }
+
+    /// Update the state based on the next [`RawBlock`].
+    pub fn update_from_raw_block<B: ByteOrder>(&mut self, raw_block: &RawBlock) -> Result<(), PcapError> {
+        match raw_block.type_ {
+            SECTION_HEADER_BLOCK | INTERFACE_DESCRIPTION_BLOCK => {
+                let block = raw_block.clone().try_into_block::<B>()?;
+                self.update_from_block(&block)
+            },
+            _ => Ok(())
+        }
+    }
+}

--- a/src/pcapng/state.rs
+++ b/src/pcapng/state.rs
@@ -61,7 +61,7 @@ impl PcapNgState {
     pub fn update_from_raw_block<B: ByteOrder>(&mut self, raw_block: &RawBlock) -> Result<(), PcapError> {
         match raw_block.type_ {
             SECTION_HEADER_BLOCK | INTERFACE_DESCRIPTION_BLOCK => {
-                let block = raw_block.clone().try_into_block::<B>()?;
+                let block = raw_block.clone().try_into_block::<B>(self)?;
                 self.update_from_block(&block)
             },
             _ => Ok(())

--- a/src/pcapng/writer.rs
+++ b/src/pcapng/writer.rs
@@ -1,12 +1,11 @@
 use std::io::Write;
 
-use byteorder_slice::{BigEndian, ByteOrder, LittleEndian};
+use byteorder_slice::{BigEndian, LittleEndian};
 
 use super::blocks::block_common::{Block, PcapNgBlock};
-use super::blocks::interface_description::{InterfaceDescriptionBlock, TsResolution};
+use super::blocks::interface_description::InterfaceDescriptionBlock;
 use super::blocks::section_header::SectionHeaderBlock;
-use super::blocks::SECTION_HEADER_BLOCK;
-use super::RawBlock;
+use super::{PcapNgState, RawBlock};
 use crate::{Endianness, PcapError, PcapResult};
 
 
@@ -34,13 +33,8 @@ use crate::{Endianness, PcapError, PcapResult};
 /// }
 /// ```
 pub struct PcapNgWriter<W: Write> {
-    /// Current section of the pcapng
-    section: SectionHeaderBlock<'static>,
-    /// List of the interfaces of the current section of the pcapng
-    interfaces: Vec<InterfaceDescriptionBlock<'static>>,
-    /// Timestamp resolutions corresponding to the interfaces
-    ts_resolutions: Vec<TsResolution>,
-
+    /// Current state of the pcapng format.
+    state: PcapNgState,
     /// Wrapped writer to which the block are written to.
     writer: W,
 }
@@ -82,12 +76,13 @@ impl<W: Write> PcapNgWriter<W> {
             Endianness::Little => section.clone().into_block().write_to::<LittleEndian, _>(&mut writer).map_err(PcapError::IoError)?,
         };
 
-        Ok(Self {
+        let state = PcapNgState {
             section: section.into_owned(),
             interfaces: Vec::new(),
-            ts_resolutions: Vec::new(),
-            writer
-        })
+            ts_resolutions: Vec::new()
+        };
+
+        Ok(Self { state, writer })
     }
 
     /// Write a [`Block`].
@@ -123,35 +118,26 @@ impl<W: Write> PcapNgWriter<W> {
     /// ```
     pub fn write_block(&mut self, block: &Block) -> PcapResult<usize> {
         match block {
-            Block::SectionHeader(blk) => {
-                self.section = blk.clone().into_owned();
-                self.interfaces.clear();
-                self.ts_resolutions.clear();
-            },
-            Block::InterfaceDescription(blk) => {
-                let ts_resolution = blk.ts_resolution()?;
-                self.ts_resolutions.push(ts_resolution);
-
-                self.interfaces.push(blk.clone().into_owned());
-            },
             Block::InterfaceStatistics(blk) => {
-                if blk.interface_id as usize >= self.interfaces.len() {
+                if blk.interface_id as usize >= self.state.interfaces.len() {
                     return Err(PcapError::InvalidInterfaceId(blk.interface_id));
                 }
             },
             Block::EnhancedPacket(blk) => {
-                if blk.interface_id as usize >= self.interfaces.len() {
+                if blk.interface_id as usize >= self.state.interfaces.len() {
                     return Err(PcapError::InvalidInterfaceId(blk.interface_id));
                 }
 
-                let ts_resol = self.ts_resolutions[blk.interface_id as usize];
+                let ts_resol = self.state.ts_resolutions[blk.interface_id as usize];
                 blk.set_write_ts_resolution(ts_resol);
             },
 
             _ => (),
         }
 
-        match self.section.endianness {
+        self.state.update_from_block(block)?;
+
+        match self.state.section.endianness {
             Endianness::Big => block.write_to::<BigEndian, _>(&mut self.writer).map_err(PcapError::IoError),
             Endianness::Little => block.write_to::<LittleEndian, _>(&mut self.writer).map_err(PcapError::IoError),
         }
@@ -196,18 +182,19 @@ impl<W: Write> PcapNgWriter<W> {
     ///
     /// Doesn't check the validity of the written blocks.
     pub fn write_raw_block(&mut self, block: &RawBlock) -> PcapResult<usize> {
-        return match self.section.endianness {
-            Endianness::Big => inner::<BigEndian, _>(&mut self.section, block, &mut self.writer),
-            Endianness::Little => inner::<LittleEndian, _>(&mut self.section, block, &mut self.writer),
-        };
-
-        // Write a RawBlock to a writer
-        fn inner<B: ByteOrder, W: Write>(section: &mut SectionHeaderBlock, block: &RawBlock, writer: &mut W) -> PcapResult<usize> {
-            if block.type_ == SECTION_HEADER_BLOCK {
-                *section = block.clone().try_into_block::<B>()?.into_owned().into_section_header().unwrap();
+        match self.state.section.endianness {
+            Endianness::Big => {
+                let written = block.write_to::<BigEndian, _>(&mut self.writer)
+                    .map_err(PcapError::IoError)?;
+                self.state.update_from_raw_block::<BigEndian>(block)?;
+                Ok(written)
+            },
+            Endianness::Little => {
+                let written = block.write_to::<LittleEndian, _>(&mut self.writer)
+                    .map_err(PcapError::IoError)?;
+                self.state.update_from_raw_block::<LittleEndian>(block)?;
+                Ok(written)
             }
-
-            block.write_to::<B, _>(writer).map_err(PcapError::IoError)
         }
     }
 
@@ -230,11 +217,11 @@ impl<W: Write> PcapNgWriter<W> {
 
     /// Return the current [`SectionHeaderBlock`].
     pub fn section(&self) -> &SectionHeaderBlock<'static> {
-        &self.section
+        &self.state.section
     }
 
     /// Return all the current [`InterfaceDescriptionBlock`].
     pub fn interfaces(&self) -> &[InterfaceDescriptionBlock<'static>] {
-        &self.interfaces
+        &self.state.interfaces
     }
 }

--- a/src/pcapng/writer.rs
+++ b/src/pcapng/writer.rs
@@ -82,12 +82,8 @@ impl<W: Write> PcapNgWriter<W> {
         state.update_from_block(&block)?;
 
         match endianness {
-            Endianness::Big => block
-                .write_to::<BigEndian, _>(&state, &mut writer)
-                .map_err(PcapError::IoError)?,
-            Endianness::Little => block
-                .write_to::<LittleEndian, _>(&state, &mut writer)
-                .map_err(PcapError::IoError)?,
+            Endianness::Big => block.write_to::<BigEndian, _>(&state, &mut writer)?,
+            Endianness::Little => block.write_to::<LittleEndian, _>(&state, &mut writer)?,
         };
 
         Ok(Self { state, writer })
@@ -144,8 +140,8 @@ impl<W: Write> PcapNgWriter<W> {
         self.state.update_from_block(block)?;
 
         match self.state.section.endianness {
-            Endianness::Big => block.write_to::<BigEndian, _>(&self.state, &mut self.writer).map_err(PcapError::IoError),
-            Endianness::Little => block.write_to::<LittleEndian, _>(&self.state, &mut self.writer).map_err(PcapError::IoError),
+            Endianness::Big => block.write_to::<BigEndian, _>(&self.state, &mut self.writer),
+            Endianness::Little => block.write_to::<LittleEndian, _>(&self.state, &mut self.writer),
         }
     }
 
@@ -190,14 +186,12 @@ impl<W: Write> PcapNgWriter<W> {
     pub fn write_raw_block(&mut self, block: &RawBlock) -> PcapResult<usize> {
         match self.state.section.endianness {
             Endianness::Big => {
-                let written = block.write_to::<BigEndian, _>(&mut self.writer)
-                    .map_err(PcapError::IoError)?;
+                let written = block.write_to::<BigEndian, _>(&mut self.writer)?;
                 self.state.update_from_raw_block::<BigEndian>(block)?;
                 Ok(written)
             },
             Endianness::Little => {
-                let written = block.write_to::<LittleEndian, _>(&mut self.writer)
-                    .map_err(PcapError::IoError)?;
+                let written = block.write_to::<LittleEndian, _>(&mut self.writer)?;
                 self.state.update_from_raw_block::<LittleEndian>(block)?;
                 Ok(written)
             }


### PR DESCRIPTION
Up to release 2.0.0, the variable timestamp formats in PcapNg were not handled at all.

PR #37 added support for variable resolution for the timestamp field in `ExpandedPacketBlock`, but this only addressed one aspect of the timestamping issues.
- There are also timestamps in the `InterfaceStatisticsBlock`, the `IsbStartTime` and `IsbEndTime` options, and the obsolete but still supported `PacketBlock`, all of which are defined to follow the same encoding/decoding rules.
- The timestamp resolution is not the only thing affecting encoding/decoding. There is also the `IfTsOffset` option, which defines an offset in seconds that must be added or subtracted to relate timestamps to absolute time.

The previous fix also introduced some new problems:
- The `EnhancedPacketBlock` type became no longer constructable, because of the new private `write_ts_resolution` field, as observed in #39. This complicates constructing new packets to save to a file.
- A `PcapError::TimestampTooBig` variant was added, but could never be returned, because the paths that lead to this failure were only able to return `std::io::Error`.

This PR introduces a broader solution that addresses all of the above problems. The fundamental issue is that correctly encoding or decoding a block requires knowledge of the protocol state.

Currently, that state is maintained in the `section`, `interfaces` and `ts_resolutions` fields on `PcapNgParser` and `PcapNgWriter`. The first step in this PR is to centralise that state into a common `PcapNgState` type. All work necessary to update that state is centralised into its `update_from_block` method.

All APIs that convert to and from `Block` are modified to require a reference to a `PcapNgState`. This allows encoding and decoding to be state-dependent. Timestamp encoding and decoding can then be correctly implemented wherever timestamps appear, by calling into helper methods on `PcapNgState` in the `from_slice` and `write_to` methods of each block type. This eliminates the need to fix things up outside those methods.

All timestamps which appear in blocks and options are now represented as a `Duration`.

This approach requires some one-off API changes, but provides a full solution, and also allows for correctly implementing any other state-dependent encoding/decoding of other blocks and options in the future.