### PR TITLE
Make block_common and opt_common public

### DIFF
--- a/src/pcapng/blocks/mod.rs
+++ b/src/pcapng/blocks/mod.rs
@@ -1,11 +1,11 @@
 //! Contains the PcapNg blocks.
 
-pub(crate) mod block_common;
+pub mod block_common;
 pub mod enhanced_packet;
 pub mod interface_description;
 pub mod interface_statistics;
 pub mod name_resolution;
-pub(crate) mod opt_common;
+pub mod opt_common;
 pub mod packet;
 pub mod section_header;
 pub mod simple_packet;


### PR DESCRIPTION
This would be useful in order to be able to create CustomBinaryOption instances from custom capture software.

Use cases include recording additional timestamps for a specific packet (for example, hardware timestamp at NIC vs timestamp at CPU).