### PR TITLE
API additions for PcapNG custom blocks

### DIFF
--- a/src/pcap/parser.rs
+++ b/src/pcap/parser.rs
@@ -3,6 +3,7 @@ use byteorder_slice::{BigEndian, LittleEndian};
 use super::RawPcapPacket;
 use crate::errors::*;
 use crate::pcap::{PcapHeader, PcapPacket};
+use crate::read_buffer::Parser;
 use crate::Endianness;
 
 
@@ -76,5 +77,53 @@ impl PcapParser {
     /// Returns the header of the pcap file.
     pub fn header(&self) -> PcapHeader {
         self.header
+    }
+}
+
+impl<'a> Parser<'a, PcapParser, ()> for () {
+    fn next_item(&self, src: &'a [u8])
+        -> Result<(&'a [u8], PcapParser), PcapError>
+    {
+        PcapParser::new(src)
+    }
+
+    fn update_state(&mut self, _item: &PcapParser) -> Result<(), PcapError> {
+        Ok(())
+    }
+
+    fn state(&self) -> &() {
+        &()
+    }
+}
+
+impl<'a> Parser<'a, PcapPacket<'a>, PcapHeader> for PcapParser {
+    fn next_item(&self, src: &'a [u8])
+        -> Result<(&'a [u8], PcapPacket<'a>), PcapError>
+    {
+        self.next_packet(src)
+    }
+
+    fn update_state(&mut self, _packet: &PcapPacket) -> Result<(), PcapError> {
+        Ok(())
+    }
+
+    fn state(&self) -> &PcapHeader {
+        &self.header
+    }
+}
+
+impl<'a> Parser<'a, RawPcapPacket<'a>, PcapHeader> for PcapParser {
+    fn next_item(&self, src: &'a [u8])
+        -> Result<(&'a [u8], RawPcapPacket<'a>), PcapError>
+    {
+        self.next_raw_packet(src)
+    }
+
+    fn update_state(&mut self, _packet: &RawPcapPacket) -> Result<(), PcapError> {
+        Ok(())
+    }
+
+    fn state(&self) -> &PcapHeader {
+        &self.header
     }
 }

--- a/src/pcap/reader.rs
+++ b/src/pcap/reader.rs
@@ -45,7 +45,9 @@ impl<R: Read> PcapReader<R> {
     /// The underlying data are not readable.
     pub fn new(reader: R) -> Result<PcapReader<R>, PcapError> {
         let mut reader = ReadBuffer::new(reader);
-        let parser = reader.parse_with(PcapParser::new)?;
+        let parser = reader
+            .parse_with(&mut ())
+            .map(|(parser, _state)| parser)?;
 
         Ok(PcapReader { parser, reader })
     }
@@ -60,7 +62,9 @@ impl<R: Read> PcapReader<R> {
         match self.reader.has_data_left() {
             Ok(has_data) => {
                 if has_data {
-                    Some(self.reader.parse_with(|src| self.parser.next_packet(src)))
+                    Some(self.reader.parse_with(&mut self.parser)
+                        .map(|(packet, _state)| packet)
+                    )
                 }
                 else {
                     None
@@ -75,7 +79,9 @@ impl<R: Read> PcapReader<R> {
         match self.reader.has_data_left() {
             Ok(has_data) => {
                 if has_data {
-                    Some(self.reader.parse_with(|src| self.parser.next_raw_packet(src)))
+                    Some(self.reader.parse_with(&mut self.parser)
+                        .map(|(packet, _state)| packet)
+                    )
                 }
                 else {
                     None

--- a/src/pcapng/blocks/custom.rs
+++ b/src/pcapng/blocks/custom.rs
@@ -1,0 +1,93 @@
+//! Custom Block.
+
+use std::borrow::Cow;
+use std::io::Write;
+
+use byteorder_slice::{ByteOrder, BigEndian, LittleEndian};
+use byteorder_slice::byteorder::{ReadBytesExt, WriteBytesExt};
+
+use super::block_common::{Block, PcapNgBlock};
+use crate::pcapng::PcapNgState;
+use crate::{Endianness, PcapError};
+
+/// Custom block
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct CustomBlock<'a, const COPIABLE: bool> {
+    /// Private Enterprise Number of the entity which defined this block.
+    pub pen: u32,
+    /// Payload of this block.
+    pub payload: Cow<'a, [u8]>,
+}
+
+impl<'a, const COPIABLE: bool> CustomBlock<'a, COPIABLE> {
+    /// Converts this block's payload into a type that implements [`PcapNgCustom`].
+    pub fn interpret<'b: 'a, T: PcapNgCustom<'a>>(&'b self, state: &PcapNgState) -> Result<Option<T>, PcapError> {
+        Ok(match state.section.endianness {
+            Endianness::Big => T::from_slice::<BigEndian>(state, &self.payload)?,
+            Endianness::Little => T::from_slice::<LittleEndian>(state, &self.payload)?,
+        })
+    }
+
+    /// Create a new custom block from a PEN, a payload and a [`PcapNgState`].
+    pub fn new<T: PcapNgCustom<'a>>(pen: u32, payload: &T, state: &PcapNgState) -> Result<Self, PcapError> {
+        Ok(CustomBlock {
+            pen,
+            payload: Cow::Owned(payload.to_bytes(state)?),
+        })
+    }
+
+    // The into_owned method must be implemented manually,
+    // since derive_into_owned can't handle the const generic.
+
+    /// Returns a version of self with all fields converted to owning versions.
+    pub fn into_owned(self) -> CustomBlock<'static, COPIABLE> {
+        CustomBlock {
+            pen: self.pen,
+            payload: Cow::Owned(self.payload.into_owned())
+        }
+    }
+}
+
+/// Common interface for custom block payloads
+pub trait PcapNgCustom<'a> {
+    /// Try to parse this payload from a slice.
+    fn from_slice<B: ByteOrder>(state: &PcapNgState, slice: &'a [u8]) -> Result<Option<Self>, PcapError>
+        where Self: Sized;
+
+    /// Write this payload into a writer.
+    fn write_to<B: ByteOrder, W: Write>(&self, state: &PcapNgState, writer: &mut W) -> Result<usize, PcapError>;
+
+    /// Convert this payload into its raw bytes.
+    fn to_bytes(&self, state: &PcapNgState) -> Result<Vec<u8>, PcapError> {
+        let mut buf = Vec::new();
+        match state.section.endianness {
+            Endianness::Big => self.write_to::<BigEndian, _>(state, &mut buf)?,
+            Endianness::Little => self.write_to::<LittleEndian, _>(state, &mut buf)?,
+        };
+        Ok(buf)
+    }
+}
+
+impl<'a, const COPIABLE: bool> PcapNgBlock<'a> for CustomBlock<'a, COPIABLE> {
+    fn from_slice<B: ByteOrder>(_state: &PcapNgState, mut slice: &'a [u8]) -> Result<(&'a [u8], Self), PcapError>
+    where
+        Self: Sized,
+    {
+        let pen = slice.read_u32::<B>()?;
+        Ok((&[], CustomBlock { pen, payload: Cow::Borrowed(slice) }))
+    }
+
+    fn write_to<B: ByteOrder, W: Write>(&self, _state: &PcapNgState, writer: &mut W) -> Result<usize, PcapError> {
+        writer.write_u32::<B>(self.pen)?;
+        writer.write_all(&self.payload)?;
+        Ok(4 + self.payload.len())
+    }
+
+    fn into_block(self) -> Block<'a> {
+        if COPIABLE {
+            Block::CustomCopiable(CustomBlock { pen: self.pen, payload: self.payload })
+        } else {
+            Block::CustomNonCopiable(CustomBlock { pen: self.pen, payload: self.payload })
+        }
+    }
+}

--- a/src/pcapng/blocks/mod.rs
+++ b/src/pcapng/blocks/mod.rs
@@ -1,6 +1,7 @@
 //! Contains the PcapNg blocks.
 
 pub(crate) mod block_common;
+pub mod custom;
 pub mod enhanced_packet;
 pub mod interface_description;
 pub mod interface_statistics;

--- a/src/pcapng/parser.rs
+++ b/src/pcapng/parser.rs
@@ -6,6 +6,7 @@ use super::blocks::enhanced_packet::EnhancedPacketBlock;
 use super::blocks::interface_description::InterfaceDescriptionBlock;
 use super::blocks::section_header::SectionHeaderBlock;
 use crate::errors::PcapError;
+use crate::read_buffer::Parser;
 use crate::Endianness;
 
 
@@ -115,5 +116,62 @@ impl PcapNgParser {
     /// Returns the [`InterfaceDescriptionBlock`] corresponding to the given packet.
     pub fn packet_interface(&self, packet: &EnhancedPacketBlock) -> Option<&InterfaceDescriptionBlock> {
         self.state.interfaces.get(packet.interface_id as usize)
+    }
+}
+
+impl<'a> Parser<'a, PcapNgParser, ()> for () {
+    fn next_item(&self, src: &'a [u8])
+        -> Result<(&'a [u8], PcapNgParser), PcapError>
+    {
+        PcapNgParser::new(src)
+    }
+
+    fn update_state(&mut self, _item: &PcapNgParser) -> Result<(), PcapError> {
+        Ok(())
+    }
+
+    fn state(&self) -> &() {
+        &()
+    }
+}
+
+impl<'a> Parser<'a, Block<'a>, PcapNgState> for PcapNgParser {
+    fn next_item(&self, src: &'a [u8])
+        -> Result<(&'a [u8], Block<'a>), PcapError>
+    {
+        match self.state.section.endianness {
+            Endianness::Big => Block::from_slice::<BigEndian>(&self.state, src),
+            Endianness::Little => Block::from_slice::<LittleEndian>(&self.state, src),
+        }
+    }
+
+    fn update_state(&mut self, block: &Block<'a>) -> Result<(), PcapError> {
+        self.state.update_from_block(block)
+    }
+
+    fn state(&self) -> &PcapNgState {
+        &self.state
+    }
+}
+
+impl<'a> Parser<'a, RawBlock<'a>, PcapNgState> for PcapNgParser {
+    fn next_item<'b>(&self, src: &'a [u8])
+        -> Result<(&'a [u8], RawBlock<'a>), PcapError>
+    {
+        match self.state.section.endianness {
+            Endianness::Big => RawBlock::from_slice::<BigEndian>(src),
+            Endianness::Little => RawBlock::from_slice::<LittleEndian>(src),
+        }
+    }
+
+    fn update_state(&mut self, block: &RawBlock<'a>) -> Result<(), PcapError> {
+        match self.state.section.endianness {
+            Endianness::Big => self.state.update_from_raw_block::<BigEndian>(block),
+            Endianness::Little => self.state.update_from_raw_block::<LittleEndian>(block),
+        }
+    }
+
+    fn state(&self) -> &PcapNgState {
+        &self.state
     }
 }

--- a/src/pcapng/reader.rs
+++ b/src/pcapng/reader.rs
@@ -4,7 +4,7 @@ use super::blocks::block_common::{Block, RawBlock};
 use super::blocks::enhanced_packet::EnhancedPacketBlock;
 use super::blocks::interface_description::InterfaceDescriptionBlock;
 use super::blocks::section_header::SectionHeaderBlock;
-use super::PcapNgParser;
+use super::{PcapNgParser, PcapNgState};
 use crate::errors::PcapError;
 use crate::read_buffer::ReadBuffer;
 
@@ -45,21 +45,27 @@ impl<R: Read> PcapNgReader<R> {
         Ok(Self { parser, reader })
     }
 
-    /// Returns the next [`Block`].
-    pub fn next_block(&mut self) -> Option<Result<Block, PcapError>> {
+    /// Returns the next [`Block`] and the current [`PcapNgState`].
+    pub fn next_block_and_state(&mut self) -> Option<Result<(Block, &PcapNgState), PcapError>> {
         match self.reader.has_data_left() {
             Ok(has_data) => {
                 if has_data {
-                    Some(self.reader
-                        .parse_with(&mut self.parser)
-                        .map(|(block, _state)| block)
-                    )
+                    Some(self.reader.parse_with(&mut self.parser))
                 }
                 else {
                     None
                 }
             },
             Err(e) => Some(Err(PcapError::IoError(e))),
+        }
+    }
+
+    /// Returns the next [`Block`].
+    pub fn next_block(&mut self) -> Option<Result<Block, PcapError>> {
+        match self.next_block_and_state() {
+            None => None,
+            Some(Ok((block, _state))) => Some(Ok(block)),
+            Some(Err(e)) => Some(Err(e))
         }
     }
 

--- a/src/pcapng/reader.rs
+++ b/src/pcapng/reader.rs
@@ -39,7 +39,9 @@ impl<R: Read> PcapNgReader<R> {
     /// Parses the first block which must be a valid SectionHeaderBlock.
     pub fn new(reader: R) -> Result<PcapNgReader<R>, PcapError> {
         let mut reader = ReadBuffer::new(reader);
-        let parser = reader.parse_with(PcapNgParser::new)?;
+        let parser = reader
+            .parse_with(&mut ())
+            .map(|(parser, _state)| parser)?;
         Ok(Self { parser, reader })
     }
 
@@ -48,7 +50,10 @@ impl<R: Read> PcapNgReader<R> {
         match self.reader.has_data_left() {
             Ok(has_data) => {
                 if has_data {
-                    Some(self.reader.parse_with(|src| self.parser.next_block(src)))
+                    Some(self.reader
+                        .parse_with(&mut self.parser)
+                        .map(|(block, _state)| block)
+                    )
                 }
                 else {
                     None
@@ -63,7 +68,10 @@ impl<R: Read> PcapNgReader<R> {
         match self.reader.has_data_left() {
             Ok(has_data) => {
                 if has_data {
-                    Some(self.reader.parse_with(|src| self.parser.next_raw_block(src)))
+                    Some(self.reader
+                        .parse_with(&mut self.parser)
+                        .map(|(block, _state)| block)
+                    )
                 }
                 else {
                     None

--- a/src/pcapng/state.rs
+++ b/src/pcapng/state.rs
@@ -41,6 +41,16 @@ pub struct PcapNgState {
 }
 
 impl PcapNgState {
+    /// Returns the current [`SectionHeaderBlock`].
+    pub fn section(&self) -> &SectionHeaderBlock<'static> {
+        &self.section
+    }
+
+    /// Returns all the current [`InterfaceDescriptionBlock`].
+    pub fn interfaces(&self) -> &[InterfaceDescriptionBlock<'static>] {
+        &self.interfaces[..]
+    }
+
     /// Update the state based on the next [`Block`].
     pub fn update_from_block(&mut self, block: &Block) -> Result<(), PcapError> {
         match block {

--- a/src/pcapng/state.rs
+++ b/src/pcapng/state.rs
@@ -82,7 +82,7 @@ impl PcapNgState {
     }
 
     /// Decode a timestamp using the correct format for the current state.
-    pub(crate) fn decode_timestamp<B: ByteOrder>(&self, interface_id: u32, slice: &mut &[u8]) -> Result<Duration, PcapError> {
+    pub fn decode_timestamp<B: ByteOrder>(&self, interface_id: u32, slice: &mut &[u8]) -> Result<Duration, PcapError> {
 
         let timestamp_high = slice
             .read_u32::<B>()
@@ -105,7 +105,7 @@ impl PcapNgState {
     }
 
     /// Encode a timestamp using the correct format for the current state.
-    pub(crate) fn encode_timestamp<B: ByteOrder, W: Write>(&self, interface_id: u32, timestamp: Duration, writer: &mut W) -> Result<(), PcapError> {
+    pub fn encode_timestamp<B: ByteOrder, W: Write>(&self, interface_id: u32, timestamp: Duration, writer: &mut W) -> Result<(), PcapError> {
 
         let (ts_resolution, ts_offset) = self
             .ts_parameters

--- a/src/pcapng/state.rs
+++ b/src/pcapng/state.rs
@@ -30,7 +30,7 @@ use {
 /// with [`PcapNgState::default`], and then update it by calling
 /// [`PcapNgState::update_from_block`] or [`PcapNgState::update_from_raw_block`].
 ///
-#[derive(Debug, Default)]
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
 pub struct PcapNgState {
     /// Current section of the pcapng
     pub(crate) section: SectionHeaderBlock<'static>,

--- a/src/pcapng/writer.rs
+++ b/src/pcapng/writer.rs
@@ -215,6 +215,11 @@ impl<W: Write> PcapNgWriter<W> {
         &mut self.writer
     }
 
+    /// Access the current [`PcapNgState`].
+    pub fn state(&self) -> &PcapNgState {
+        &self.state
+    }
+
     /// Return the current [`SectionHeaderBlock`].
     pub fn section(&self) -> &SectionHeaderBlock<'static> {
         &self.state.section

--- a/src/read_buffer.rs
+++ b/src/read_buffer.rs
@@ -2,6 +2,17 @@ use std::io::{Error, ErrorKind, Read};
 
 use crate::PcapError;
 
+/// Trait implemented by parsers.
+pub(crate) trait Parser<'a, Item: 'a, State> where Self: Sized {
+    /// Gets the next item from the parser.
+    fn next_item(&self, src: &'a [u8]) -> Result<(&'a [u8], Item), PcapError>;
+
+    /// Updates the parser state for the item.
+    fn update_state(&mut self, item: &Item) -> Result<(), PcapError>;
+
+    /// Gets the current state from the parser.
+    fn state(&self) -> &State;
+}
 
 /// Internal structure that bufferize its input and allow to parse element from its buffer.
 #[derive(Debug)]
@@ -34,11 +45,11 @@ impl<R: Read> ReadBuffer<R> {
     /// Safety
     ///
     /// The parser must NOT keep a reference to the buffer in input.
-    pub fn parse_with<'a, 'b: 'a, 'c: 'a, F, O>(&'c mut self, mut parser: F) -> Result<O, PcapError>
+    pub fn parse_with<'a, 'b: 'a, 'c: 'a, 'd: 'a, P, O, S>(&'c mut self, parser: &'d mut P) -> Result<(O, &'d S), PcapError>
     where
-        F: FnMut(&'a [u8]) -> Result<(&'a [u8], O), PcapError>,
-        F: 'b,
+        P: Parser<'a, O, S> + 'b,
         O: 'a,
+        S: 'd,
     {
         loop {
             let buf = &self.buffer[self.pos..self.len];
@@ -46,11 +57,8 @@ impl<R: Read> ReadBuffer<R> {
             // Sound because 'b and 'c must outlive 'a so the buffer cannot be modified while someone has a ref on it
             let buf: &'a [u8] = unsafe { std::mem::transmute(buf) };
 
-            match parser(buf) {
-                Ok((rem, value)) => {
-                    self.advance_with_slice(rem);
-                    return Ok(value);
-                },
+            let (rem, item) = match parser.next_item(buf) {
+                Ok(x) => x,
 
                 Err(PcapError::IncompleteBuffer) => {
                     // The parsed data len should never be more than the buffer capacity
@@ -62,10 +70,18 @@ impl<R: Read> ReadBuffer<R> {
                     if nb_read == 0 {
                         return Err(PcapError::IoError(Error::from(ErrorKind::UnexpectedEof)));
                     }
+
+                    continue;
                 },
 
                 Err(e) => return Err(e),
-            }
+            };
+
+            parser.update_state(&item)?;
+
+            self.advance_with_slice(rem);
+
+            return Ok((item, parser.state()))
         }
     }
 


### PR DESCRIPTION
I've been working on saving additional data to PcapNG files using custom blocks.

Custom blocks are a feature of the PcapNG format that allow it to be independently extended. Blocks defined by different organisations are identified by [Private Enterprise Numbers](https://www.iana.org/assignments/enterprise-numbers/) assigned by IANA.

There are two distinct custom block types: copiable and non-copiable. Copiable blocks are those whose meaning is self-contained, and which may be freely copied to the output of a program which does not understand their content. Non-copiable blocks are those whose meaning is dependent on any aspect of the format or content of the rest of the PcapNG file. Such blocks may not be copied without understanding their content, as they may become invalid or change meaning.

This PR adds the API features necessary to work effectively with custom blocks, including encoding and decoding payload formats in ways that reuse features of the existing PcapNG protocol state (e.g. endianness and timestamp formats).

The key elements are:

New block type constants.
```rust
/// Custom block type, copiable
pub const CUSTOM_BLOCK_COPIABLE: u32 = 0x00000BAD;
/// Custom block type, non-copiable
pub const CUSTOM_BLOCK_NON_COPIABLE: u32 = 0x40000BAD;
```

The `CustomBlock` type.
```rust
pub struct CustomBlock<'a, const COPIABLE: bool> {
    /// Private Enterprise Number of the entity which defined this block.
    pub pen: u32,
    /// Payload of this block.
    pub payload: Cow<'a, [u8]>,
}
```
New `Block` variants.
```rust
/// Custom block, copiable
CustomCopiable(CustomBlock<'a, true>),
/// Custom block, non-copiable
CustomNonCopiable(CustomBlock<'a, false>),
```
The `PcapNgCustom` trait, which can be implemented for user-defined payload types.
```rust
/// Common interface for custom block payloads
pub trait PcapNgCustom<'a> {
    /// Try to parse this payload from a slice.
    fn from_slice<B: ByteOrder>(state: &PcapNgState, slice: &'a [u8]) -> Result<Option<Self>, PcapError>;

    /// Write this payload into a writer.
    fn write_to<B: ByteOrder, W: Write>(&self, state: &PcapNgState, writer: &mut W) -> Result<usize, PcapError>;
}
```
The `new` and `interpret` methods on `CustomBlock`, which simplify writing and reading custom block formats that implement the above trait.
```rust
/// Create a new custom block from a PEN, a payload and a [`PcapNgState`].
pub fn new<T: PcapNgCustom<'a>>(pen: u32, payload: &T, state: &PcapNgState) -> Result<Self, PcapError>

/// Converts this block's payload into a type that implements [`PcapNgCustom`].
pub fn interpret<'b: 'a, T: PcapNgCustom<'a>>(&'b self, state: &PcapNgState) -> Result<Option<T>, PcapError>;
```
Another important addition is the `PcapNgReader::next_block_and_state` method, which returns a reference to the current `PcapNgState` at the same time as returning the next block.
```rust
/// Returns the next [`Block`] and the current [`PcapNgState`].
pub fn next_block_and_state(&mut self) -> Option<Result<(Block, &PcapNgState), PcapError>> {
```
This is necessary to make it possible to use the `CustomBlock::interpret` method without angering the borrow checker. 

Adding this last method required some internal refactoring of `ReadBuffer::parse_with`, to make it accept an internal `Parser` trait rather than a closure. This was necessary to break the parsing work into separate steps which have different borrowing requirements.

Additionally, new `section` and `interfaces` methods are added to `PcapNgState`, and the `encode_timestamp` and `decode_timestamp` are made public, to support their use in custom blocks.

For an example of usage, see the [custom block definition](https://github.com/greatscottgadgets/packetry/blob/ec775804943b6340b18f55e3cc488eedba1d0c96/src/file.rs#L557-L609), [writing](https://github.com/greatscottgadgets/packetry/blob/ec775804943b6340b18f55e3cc488eedba1d0c96/src/file.rs#L522-L531) and [reading](https://github.com/greatscottgadgets/packetry/blob/ec775804943b6340b18f55e3cc488eedba1d0c96/src/file.rs#L370-L396) in https://github.com/greatscottgadgets/packetry/pull/227.