### PR TITLE
API changes for PcapNG custom options

### DIFF
--- a/src/pcapng/blocks/enhanced_packet.rs
+++ b/src/pcapng/blocks/enhanced_packet.rs
@@ -120,7 +120,7 @@ pub enum EnhancedPacketOption<'a> {
 }
 
 impl<'a> PcapNgOption<'a> for EnhancedPacketOption<'a> {
-    fn from_slice<B: ByteOrder>(_state: &PcapNgState, _interface_id: Option<u32>, code: u16, length: u16, mut slice: &'a [u8]) -> Result<Self, PcapError> {
+    fn from_slice<B: ByteOrder>(_state: &PcapNgState, _interface_id: Option<u32>, code: u16, mut slice: &'a [u8]) -> Result<Self, PcapError> {
         let opt = match code {
             1 => EnhancedPacketOption::Comment(Cow::Borrowed(std::str::from_utf8(slice)?)),
             2 => {
@@ -136,7 +136,7 @@ impl<'a> PcapNgOption<'a> for EnhancedPacketOption<'a> {
                 }
                 EnhancedPacketOption::DropCount(slice.read_u64::<B>().map_err(|_| PcapError::IncompleteBuffer)?)
             },
-            _ => EnhancedPacketOption::Common(CommonOption::new::<B>(code, length, slice)?),
+            _ => EnhancedPacketOption::Common(CommonOption::new::<B>(code, slice)?),
         };
 
         Ok(opt)

--- a/src/pcapng/blocks/enhanced_packet.rs
+++ b/src/pcapng/blocks/enhanced_packet.rs
@@ -100,9 +100,6 @@ impl<'a> PcapNgBlock<'a> for EnhancedPacketBlock<'a> {
 /// The Enhanced Packet Block (EPB) options
 #[derive(Clone, Debug, IntoOwned, Eq, PartialEq)]
 pub enum EnhancedPacketOption<'a> {
-    /// Comment associated with the current block
-    Comment(Cow<'a, str>),
-
     /// 32-bit flags word containing link-layer information.
     Flags(u32),
 
@@ -122,7 +119,6 @@ pub enum EnhancedPacketOption<'a> {
 impl<'a> PcapNgOption<'a> for EnhancedPacketOption<'a> {
     fn from_slice<B: ByteOrder>(_state: &PcapNgState, _interface_id: Option<u32>, code: u16, mut slice: &'a [u8]) -> Result<Self, PcapError> {
         let opt = match code {
-            1 => EnhancedPacketOption::Comment(Cow::Borrowed(std::str::from_utf8(slice)?)),
             2 => {
                 if slice.len() != 4 {
                     return Err(PcapError::InvalidField("EnhancedPacketOption: Flags length != 4"));
@@ -144,7 +140,6 @@ impl<'a> PcapNgOption<'a> for EnhancedPacketOption<'a> {
 
     fn write_to<B: ByteOrder, W: Write>(&self, _state: &PcapNgState, _interface_id: Option<u32>, writer: &mut W) -> Result<usize, PcapError> {
         Ok(match self {
-            EnhancedPacketOption::Comment(a) => a.write_opt_to::<B, W>(1, writer),
             EnhancedPacketOption::Flags(a) => a.write_opt_to::<B, W>(2, writer),
             EnhancedPacketOption::Hash(a) => a.write_opt_to::<B, W>(3, writer),
             EnhancedPacketOption::DropCount(a) => a.write_opt_to::<B, W>(4, writer),

--- a/src/pcapng/blocks/interface_description.rs
+++ b/src/pcapng/blocks/interface_description.rs
@@ -113,10 +113,6 @@ impl<'a> InterfaceDescriptionBlock<'a> {
 /// The Interface Description Block (IDB) options
 #[derive(Clone, Debug, IntoOwned, Eq, PartialEq)]
 pub enum InterfaceDescriptionOption<'a> {
-    /// The opt_comment option is a UTF-8 string containing human-readable comment text
-    /// that is associated to the current block.
-    Comment(Cow<'a, str>),
-
     /// The if_name option is a UTF-8 string containing the name of the device used to capture data.
     IfName(Cow<'a, str>),
 
@@ -169,7 +165,6 @@ pub enum InterfaceDescriptionOption<'a> {
 impl<'a> PcapNgOption<'a> for InterfaceDescriptionOption<'a> {
     fn from_slice<B: ByteOrder>(_state: &PcapNgState, _interface_id: Option<u32>, code: u16, mut slice: &'a [u8]) -> Result<Self, PcapError> {
         let opt = match code {
-            1 => InterfaceDescriptionOption::Comment(Cow::Borrowed(std::str::from_utf8(slice)?)),
             2 => InterfaceDescriptionOption::IfName(Cow::Borrowed(std::str::from_utf8(slice)?)),
             3 => InterfaceDescriptionOption::IfDescription(Cow::Borrowed(std::str::from_utf8(slice)?)),
             4 => {
@@ -243,7 +238,6 @@ impl<'a> PcapNgOption<'a> for InterfaceDescriptionOption<'a> {
 
     fn write_to<B: ByteOrder, W: Write>(&self, _state: &PcapNgState, _interface_id: Option<u32>, writer: &mut W) -> Result<usize, PcapError> {
         Ok(match self {
-            InterfaceDescriptionOption::Comment(a) => a.write_opt_to::<B, W>(1, writer),
             InterfaceDescriptionOption::IfName(a) => a.write_opt_to::<B, W>(2, writer),
             InterfaceDescriptionOption::IfDescription(a) => a.write_opt_to::<B, W>(3, writer),
             InterfaceDescriptionOption::IfIpv4Addr(a) => a.write_opt_to::<B, W>(4, writer),

--- a/src/pcapng/blocks/interface_description.rs
+++ b/src/pcapng/blocks/interface_description.rs
@@ -167,7 +167,7 @@ pub enum InterfaceDescriptionOption<'a> {
 }
 
 impl<'a> PcapNgOption<'a> for InterfaceDescriptionOption<'a> {
-    fn from_slice<B: ByteOrder>(_state: &PcapNgState, _interface_id: Option<u32>, code: u16, length: u16, mut slice: &'a [u8]) -> Result<Self, PcapError> {
+    fn from_slice<B: ByteOrder>(_state: &PcapNgState, _interface_id: Option<u32>, code: u16, mut slice: &'a [u8]) -> Result<Self, PcapError> {
         let opt = match code {
             1 => InterfaceDescriptionOption::Comment(Cow::Borrowed(std::str::from_utf8(slice)?)),
             2 => InterfaceDescriptionOption::IfName(Cow::Borrowed(std::str::from_utf8(slice)?)),
@@ -235,7 +235,7 @@ impl<'a> PcapNgOption<'a> for InterfaceDescriptionOption<'a> {
             },
             15 => InterfaceDescriptionOption::IfHardware(Cow::Borrowed(std::str::from_utf8(slice)?)),
 
-            _ => InterfaceDescriptionOption::Common(CommonOption::new::<B>(code, length, slice)?),
+            _ => InterfaceDescriptionOption::Common(CommonOption::new::<B>(code, slice)?),
         };
 
         Ok(opt)

--- a/src/pcapng/blocks/interface_statistics.rs
+++ b/src/pcapng/blocks/interface_statistics.rs
@@ -63,10 +63,6 @@ impl<'a> PcapNgBlock<'a> for InterfaceStatisticsBlock<'a> {
 /// The Interface Statistics Block options
 #[derive(Clone, Debug, IntoOwned, Eq, PartialEq)]
 pub enum InterfaceStatisticsOption<'a> {
-    /// The opt_comment option is a UTF-8 string containing human-readable comment text
-    /// that is associated to the current block.
-    Comment(Cow<'a, str>),
-
     /// The isb_starttime option specifies the time the capture started.
     ///
     /// The time is relative to 1970-01-01 00:00:00 UTC.
@@ -104,7 +100,6 @@ pub enum InterfaceStatisticsOption<'a> {
 impl<'a> PcapNgOption<'a> for InterfaceStatisticsOption<'a> {
     fn from_slice<B: ByteOrder>(state: &PcapNgState, interface_id: Option<u32>, code: u16, mut slice: &'a [u8]) -> Result<Self, PcapError> {
         let opt = match code {
-            1 => InterfaceStatisticsOption::Comment(Cow::Borrowed(std::str::from_utf8(slice)?)),
             2 => InterfaceStatisticsOption::IsbStartTime(state.decode_timestamp::<B>(interface_id.unwrap(), &mut slice)?),
             3 => InterfaceStatisticsOption::IsbEndTime(state.decode_timestamp::<B>(interface_id.unwrap(), &mut slice)?),
             4 => InterfaceStatisticsOption::IsbIfRecv(slice.read_u64::<B>().map_err(|_| PcapError::IncompleteBuffer)?),
@@ -121,7 +116,6 @@ impl<'a> PcapNgOption<'a> for InterfaceStatisticsOption<'a> {
 
     fn write_to<B: ByteOrder, W: Write>(&self, state: &PcapNgState, interface_id: Option<u32>, writer: &mut W) -> Result<usize, PcapError> {
         Ok(match self {
-            InterfaceStatisticsOption::Comment(a) => a.write_opt_to::<B, W>(1, writer)?,
             InterfaceStatisticsOption::IsbStartTime(a) => write_timestamp::<B, W>(2, a, state, interface_id, writer)?,
             InterfaceStatisticsOption::IsbEndTime(a) => write_timestamp::<B, W>(3, a, state, interface_id, writer)?,
             InterfaceStatisticsOption::IsbIfRecv(a) => a.write_opt_to::<B, W>(4, writer)?,

--- a/src/pcapng/blocks/interface_statistics.rs
+++ b/src/pcapng/blocks/interface_statistics.rs
@@ -102,7 +102,7 @@ pub enum InterfaceStatisticsOption<'a> {
 }
 
 impl<'a> PcapNgOption<'a> for InterfaceStatisticsOption<'a> {
-    fn from_slice<B: ByteOrder>(state: &PcapNgState, interface_id: Option<u32>, code: u16, length: u16, mut slice: &'a [u8]) -> Result<Self, PcapError> {
+    fn from_slice<B: ByteOrder>(state: &PcapNgState, interface_id: Option<u32>, code: u16, mut slice: &'a [u8]) -> Result<Self, PcapError> {
         let opt = match code {
             1 => InterfaceStatisticsOption::Comment(Cow::Borrowed(std::str::from_utf8(slice)?)),
             2 => InterfaceStatisticsOption::IsbStartTime(state.decode_timestamp::<B>(interface_id.unwrap(), &mut slice)?),
@@ -113,7 +113,7 @@ impl<'a> PcapNgOption<'a> for InterfaceStatisticsOption<'a> {
             7 => InterfaceStatisticsOption::IsbOsDrop(slice.read_u64::<B>().map_err(|_| PcapError::IncompleteBuffer)?),
             8 => InterfaceStatisticsOption::IsbUsrDeliv(slice.read_u64::<B>().map_err(|_| PcapError::IncompleteBuffer)?),
 
-            _ => InterfaceStatisticsOption::Common(CommonOption::new::<B>(code, length, slice)?),
+            _ => InterfaceStatisticsOption::Common(CommonOption::new::<B>(code, slice)?),
         };
 
         Ok(opt)

--- a/src/pcapng/blocks/name_resolution.rs
+++ b/src/pcapng/blocks/name_resolution.rs
@@ -294,10 +294,6 @@ impl<'a> UnknownRecord<'a> {
 /// The Name Resolution Block (NRB) options
 #[derive(Clone, Debug, IntoOwned, Eq, PartialEq)]
 pub enum NameResolutionOption<'a> {
-    /// The opt_comment option is a UTF-8 string containing human-readable comment text
-    /// that is associated to the current block.
-    Comment(Cow<'a, str>),
-
     /// The ns_dnsname option is a UTF-8 string containing the name of the machine (DNS server) used to perform the name resolution.
     NsDnsName(Cow<'a, str>),
 
@@ -314,7 +310,6 @@ pub enum NameResolutionOption<'a> {
 impl<'a> PcapNgOption<'a> for NameResolutionOption<'a> {
     fn from_slice<B: ByteOrder>(_state: &PcapNgState, _interface_id: Option<u32>, code: u16, slice: &'a [u8]) -> Result<Self, PcapError> {
         let opt = match code {
-            1 => NameResolutionOption::Comment(Cow::Borrowed(std::str::from_utf8(slice)?)),
             2 => NameResolutionOption::NsDnsName(Cow::Borrowed(std::str::from_utf8(slice)?)),
             3 => {
                 if slice.len() != 4 {
@@ -336,7 +331,6 @@ impl<'a> PcapNgOption<'a> for NameResolutionOption<'a> {
 
     fn write_to<B: ByteOrder, W: Write>(&self, _state: &PcapNgState, _interface_id: Option<u32>, writer: &mut W) -> Result<usize, PcapError> {
         Ok(match self {
-            NameResolutionOption::Comment(a) => a.write_opt_to::<B, W>(1, writer),
             NameResolutionOption::NsDnsName(a) => a.write_opt_to::<B, W>(2, writer),
             NameResolutionOption::NsDnsIpv4Addr(a) => a.write_opt_to::<B, W>(3, writer),
             NameResolutionOption::NsDnsIpv6Addr(a) => a.write_opt_to::<B, W>(4, writer),

--- a/src/pcapng/blocks/opt_common.rs
+++ b/src/pcapng/blocks/opt_common.rs
@@ -83,6 +83,11 @@ impl<'a> CustomBinaryOption<'a, true> {
         T::from_slice(&self.value)
             .map_err(|e| PcapError::CustomConversionError(T::PEN, e.into()))
     }
+
+    /// Converts this option into a [`CommonOption`].
+    pub fn into_common_option(self) -> CommonOption<'a> {
+        CommonOption::CustomBinaryCopiable(self)
+    }
 }
 
 impl<'a> CustomBinaryOption<'a, false> {
@@ -96,6 +101,11 @@ impl<'a> CustomBinaryOption<'a, false> {
 
         T::from_slice(state, &self.value)
             .map_err(|e| PcapError::CustomConversionError(T::PEN, e.into()))
+    }
+
+    /// Converts this option into a [`CommonOption`].
+    pub fn into_common_option(self) -> CommonOption<'a> {
+        CommonOption::CustomBinaryNonCopiable(self)
     }
 }
 

--- a/src/pcapng/blocks/packet.rs
+++ b/src/pcapng/blocks/packet.rs
@@ -117,7 +117,7 @@ pub enum PacketOption<'a> {
 }
 
 impl<'a> PcapNgOption<'a> for PacketOption<'a> {
-    fn from_slice<B: ByteOrder>(_state: &PcapNgState, _interface_id: Option<u32>, code: u16, length: u16, mut slice: &'a [u8]) -> Result<Self, PcapError> {
+    fn from_slice<B: ByteOrder>(_state: &PcapNgState, _interface_id: Option<u32>, code: u16, mut slice: &'a [u8]) -> Result<Self, PcapError> {
         let opt = match code {
             1 => PacketOption::Comment(Cow::Borrowed(std::str::from_utf8(slice)?)),
             2 => {
@@ -127,7 +127,7 @@ impl<'a> PcapNgOption<'a> for PacketOption<'a> {
                 PacketOption::Flags(slice.read_u32::<B>().map_err(|_| PcapError::IncompleteBuffer)?)
             },
             3 => PacketOption::Hash(Cow::Borrowed(slice)),
-            _ => PacketOption::Common(CommonOption::new::<B>(code, length, slice)?),
+            _ => PacketOption::Common(CommonOption::new::<B>(code, slice)?),
         };
 
         Ok(opt)

--- a/src/pcapng/blocks/packet.rs
+++ b/src/pcapng/blocks/packet.rs
@@ -103,9 +103,6 @@ impl<'a> PcapNgBlock<'a> for PacketBlock<'a> {
 /// Packet Block option
 #[derive(Clone, Debug, IntoOwned, Eq, PartialEq)]
 pub enum PacketOption<'a> {
-    /// Comment associated with the current block
-    Comment(Cow<'a, str>),
-
     /// 32-bit flags word containing link-layer information.
     Flags(u32),
 
@@ -119,7 +116,6 @@ pub enum PacketOption<'a> {
 impl<'a> PcapNgOption<'a> for PacketOption<'a> {
     fn from_slice<B: ByteOrder>(_state: &PcapNgState, _interface_id: Option<u32>, code: u16, mut slice: &'a [u8]) -> Result<Self, PcapError> {
         let opt = match code {
-            1 => PacketOption::Comment(Cow::Borrowed(std::str::from_utf8(slice)?)),
             2 => {
                 if slice.len() != 4 {
                     return Err(PcapError::InvalidField("PacketOption: Flags length != 4"));
@@ -135,7 +131,6 @@ impl<'a> PcapNgOption<'a> for PacketOption<'a> {
 
     fn write_to<B: ByteOrder, W: Write>(&self, _state: &PcapNgState, _interface_id: Option<u32>, writer: &mut W) -> Result<usize, PcapError> {
         Ok(match self {
-            PacketOption::Comment(a) => a.write_opt_to::<B, W>(1, writer),
             PacketOption::Flags(a) => a.write_opt_to::<B, W>(2, writer),
             PacketOption::Hash(a) => a.write_opt_to::<B, W>(3, writer),
             PacketOption::Common(a) => a.write_opt_to::<B, W>(a.code(), writer),

--- a/src/pcapng/blocks/section_header.rs
+++ b/src/pcapng/blocks/section_header.rs
@@ -108,9 +108,6 @@ impl Default for SectionHeaderBlock<'static> {
 /// Section Header Block options
 #[derive(Clone, Debug, IntoOwned, Eq, PartialEq)]
 pub enum SectionHeaderOption<'a> {
-    /// Comment associated with the current block
-    Comment(Cow<'a, str>),
-
     /// Description of the hardware used to create this section
     Hardware(Cow<'a, str>),
 
@@ -127,7 +124,6 @@ pub enum SectionHeaderOption<'a> {
 impl<'a> PcapNgOption<'a> for SectionHeaderOption<'a> {
     fn from_slice<B: ByteOrder>(_state: &PcapNgState, _interface_id: Option<u32>, code: u16, slice: &'a [u8]) -> Result<Self, PcapError> {
         let opt = match code {
-            1 => SectionHeaderOption::Comment(Cow::Borrowed(std::str::from_utf8(slice)?)),
             2 => SectionHeaderOption::Hardware(Cow::Borrowed(std::str::from_utf8(slice)?)),
             3 => SectionHeaderOption::OS(Cow::Borrowed(std::str::from_utf8(slice)?)),
             4 => SectionHeaderOption::UserApplication(Cow::Borrowed(std::str::from_utf8(slice)?)),
@@ -140,7 +136,6 @@ impl<'a> PcapNgOption<'a> for SectionHeaderOption<'a> {
 
     fn write_to<B: ByteOrder, W: Write>(&self, _state: &PcapNgState, _interface_id: Option<u32>, writer: &mut W) -> Result<usize, PcapError> {
         Ok(match self {
-            SectionHeaderOption::Comment(a) => a.write_opt_to::<B, W>(1, writer),
             SectionHeaderOption::Hardware(a) => a.write_opt_to::<B, W>(2, writer),
             SectionHeaderOption::OS(a) => a.write_opt_to::<B, W>(3, writer),
             SectionHeaderOption::UserApplication(a) => a.write_opt_to::<B, W>(4, writer),

--- a/src/pcapng/blocks/section_header.rs
+++ b/src/pcapng/blocks/section_header.rs
@@ -125,14 +125,14 @@ pub enum SectionHeaderOption<'a> {
 }
 
 impl<'a> PcapNgOption<'a> for SectionHeaderOption<'a> {
-    fn from_slice<B: ByteOrder>(_state: &PcapNgState, _interface_id: Option<u32>, code: u16, length: u16, slice: &'a [u8]) -> Result<Self, PcapError> {
+    fn from_slice<B: ByteOrder>(_state: &PcapNgState, _interface_id: Option<u32>, code: u16, slice: &'a [u8]) -> Result<Self, PcapError> {
         let opt = match code {
             1 => SectionHeaderOption::Comment(Cow::Borrowed(std::str::from_utf8(slice)?)),
             2 => SectionHeaderOption::Hardware(Cow::Borrowed(std::str::from_utf8(slice)?)),
             3 => SectionHeaderOption::OS(Cow::Borrowed(std::str::from_utf8(slice)?)),
             4 => SectionHeaderOption::UserApplication(Cow::Borrowed(std::str::from_utf8(slice)?)),
 
-            _ => SectionHeaderOption::Common(CommonOption::new::<B>(code, length, slice)?),
+            _ => SectionHeaderOption::Common(CommonOption::new::<B>(code, slice)?),
         };
 
         Ok(opt)


### PR DESCRIPTION
This follows on from #47 and extends the same API features discussed there to custom options.

Firstly I propose some restructuring, to avoid duplicating these changes several times.

Currently, all the block-specific option enums each have `CustomBinary`, `CustomUtf8` and `Unknown` variants. The code for dealing with these is duplicated for each block type. To centralise this, we can define a `CommonOption` enum with just those three variants:

```rust
pub enum CommonOption<'a> {
    /// Custom option containing binary octets in the Custom Data portion
    CustomBinary(CustomBinaryOption<'a>),

    /// Custom option containing a UTF-8 string in the Custom Data portion
    CustomUtf8(CustomUtf8Option<'a>),

    /// Unknown option
    Unknown(UnknownOption<'a>),
}
```
and give each block-specific enum a `Common` variant instead:
```rust
    /// A common option applicable to any block type.
    Common(CommonOption<'a>),
```

A lot of duplicated code can then be centralised into methods on the `CommonOption` type.

This would be another API-breaking change for 3.0.0, but one that I think is worthwhile. It avoids a lot of internal duplication, and would also allow users to implement unified handling of these common options. It also gives us somewhere to put any other "special" option codes that might be defined in future versions of the PcapNG spec.

This PR also removes the `length` fields from `UnknownBlock` and `UnknownRecord`. Both are redundant, since the length is that of the associated slice.

With those cleanups out of the way, we then split the `CustomBinaryOption` and `CustomUtf8Option` types into separate copiable and non-copiable versions, as done for `CustomBlock` in #47.

Support for encoding and decoding custom binary options is added using the same traits as for custom blocks:

- An `CustomBinaryOption::interpret` method, which converts to from `CustomBinaryOption` to `CustomCopiable` or `CustomNonCopiable`, as appropriate.
- An `into_custom_option` method on the `CustomCopiable` and `CustomNonCopiable` traits, to convert to `CustomBinaryOption`.
- An `into_common_option` method to convert from `CustomBinaryOption` to `CommonOption`.

Finally, the existing tests for custom blocks are extended to include writing and reading back custom options.