### PR TITLE
feat: Harmonize parser and reader APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ let mut pcapng_reader = PcapNgReader::new(file_in).unwrap();
 // Read test.pcapng
 while let Some(block) = pcapng_reader.next_block() {
     // Check if there is no error
-    let block = block.unwrap();
+    let (block, state) = block.unwrap();
 
     //  Do something
 }

--- a/src/pcap/parser.rs
+++ b/src/pcap/parser.rs
@@ -35,8 +35,10 @@ use crate::pcap::PcapPacket;
 ///                 break;
 ///             }
 ///         },
-///         Err(PcapError::IncompleteBuffer) => {}, // Load more data into src
-///         Err(_) => {},                           // Parsing error
+///         Err(PcapError::IncompleteBuffer(_,_)) => {}, // Load more data into src
+///         Err(_) => {
+///             // Parsing error, unrecoverable
+///         },
 ///     }
 /// }
 /// ```
@@ -56,6 +58,11 @@ impl PcapParser {
     }
 
     /// Returns the remainder and the next [`PcapPacket`].
+    /// 
+    /// # Errors
+    /// - [`PcapError::IncompleteBuffer`] is recoverable (by loading more data).
+    /// - Other errors will prevent the parser from advancing further.
+    ///   Some can be recovered by calling [`PcapParser::next_raw_packet`].
     pub fn next_packet<'a>(&self, slice: &'a [u8]) -> PcapResult<(&'a [u8], PcapPacket<'a>)> {
         let res = match self.header.endianness {
             Endianness::Big => RawPcapPacket::from_slice::<BigEndian>(slice),
@@ -67,6 +74,13 @@ impl PcapParser {
     }
 
     /// Returns the remainder and the next [`RawPcapPacket`].
+    /// 
+    /// More permissive than [`Self::next_packet`], can be used to parse malformed files.
+    /// 
+    /// A [`RawPcapPacket`] can be validated using [`RawPcapPacket::try_into_pcap_packet`].
+    /// 
+    /// # Errors
+    /// - Only [`PcapError::IncompleteBuffer`] can happen. It is recoverable by loading more data.
     pub fn next_raw_packet<'a>(&self, slice: &'a [u8]) -> PcapResult<(&'a [u8], RawPcapPacket<'a>)> {
         match self.header.endianness {
             Endianness::Big => RawPcapPacket::from_slice::<BigEndian>(slice),

--- a/src/pcap/reader.rs
+++ b/src/pcap/reader.rs
@@ -55,13 +55,34 @@ impl<R: Read> PcapReader<R> {
     }
 
     /// Returns the next [`PcapPacket`].
+    /// [`None`] means that the reader have reached the EoF.
+    /// Won't advance the reader past any malformed packets.
+    ///
+    /// # Errors
+    /// - Some variants of [`PcapError::IoError`] can be retried.
+    /// - Other variants can be retried using [`Self::next_raw_packet`] to parse the faulty packet.
     pub fn next_packet(&mut self) -> Option<Result<PcapPacket<'_>, PcapError>> {
-        let header = self.parser.header();
-        self.next_raw_packet()
-            .map(|res| res.and_then(|raw_pkt| PcapPacket::try_from_raw_packet(raw_pkt, header.ts_resolution, header.snaplen)))
+        match self.reader.has_data_left() {
+            Ok(has_data) => {
+                if has_data {
+                    Some(self.reader.parse_with(|src| self.parser.next_packet(src)))
+                } else {
+                    None
+                }
+            },
+            Err(e) => Some(Err(PcapError::IoError(e))),
+        }
     }
 
     /// Returns the next [`RawPcapPacket`].
+    /// [`None`] means that the reader have reached the EoF.
+    /// 
+    /// More permissive than [`Self::next_packet`], can be used to parse malformed files.
+    /// 
+    /// A [`RawPcapPacket`] can be validated using [`RawPcapPacket::try_into_pcap_packet`].
+    ///
+    /// # Errors
+    /// - Only [`PcapError::IoError`] can happen, some of its variants can be retried.
     pub fn next_raw_packet(&mut self) -> Option<Result<RawPcapPacket<'_>, PcapError>> {
         match self.reader.has_data_left() {
             Ok(has_data) => {
@@ -74,7 +95,7 @@ impl<R: Read> PcapReader<R> {
             Err(e) => Some(Err(PcapError::IoError(e))),
         }
     }
-
+    
     /// Returns the global header of the pcap.
     pub fn header(&self) -> PcapHeader {
         self.parser.header()

--- a/src/pcapng/blocks/block_common.rs
+++ b/src/pcapng/blocks/block_common.rs
@@ -141,7 +141,17 @@ impl<'a> RawBlock<'a> {
     }
 
     /// Tries to convert a [`RawBlock`] into a [`Block`], using a [`PcapNgState`].
-    pub fn try_into_block<B: ByteOrder>(self, state: &PcapNgState) -> PcapResult<Block<'a>> {
+    /// The byteorder is defined by the `state`.
+    pub fn try_into_block(self, state: &PcapNgState) -> PcapResult<Block<'a>> {
+        match state.section.endianness {
+            crate::Endianness::Big => Block::try_from_raw_block::<BigEndian>(state, self),
+            crate::Endianness::Little => Block::try_from_raw_block::<LittleEndian>(state, self),
+        }
+    }
+    
+    /// Tries to convert a [`RawBlock`] into a [`Block`], using a [`PcapNgState`].
+    /// The byteorder is defined by the caller
+    pub fn try_into_block_with_byteorder<B: ByteOrder>(self, state: &PcapNgState) -> PcapResult<Block<'a>> {
         Block::try_from_raw_block::<B>(state, self)
     }
 }

--- a/src/pcapng/parser.rs
+++ b/src/pcapng/parser.rs
@@ -5,9 +5,8 @@ use super::blocks::block_common::{Block, RawBlock};
 use super::blocks::enhanced_packet::EnhancedPacketBlock;
 use super::blocks::interface_description::InterfaceDescriptionBlock;
 use super::blocks::section_header::SectionHeaderBlock;
-use crate::errors::PcapError;
 use crate::Endianness;
-
+use crate::errors::PcapError;
 
 /// Parses a PcapNg from a slice of bytes.
 ///
@@ -34,7 +33,7 @@ use crate::Endianness;
 ///             // Don't forget to update src
 ///             src = rem;
 ///         },
-///         Err(PcapError::IncompleteBuffer) => {
+///         Err(PcapError::IncompleteBuffer(_,_)) => {
 ///             // Load more data into src
 ///         },
 ///         Err(_) => {
@@ -70,23 +69,27 @@ impl PcapNgParser {
     }
 
     /// Returns the remainder and the next [`Block`].
+    ///
+    /// # Errors
+    /// - Only [`PcapError::IncompleteBuffer`] is recoverable (by loading more data).
+    /// - Other errors will prevent the parser from advancing further.
+    ///   Some can be recovered by calling [`Self::next_raw_block`].
     pub fn next_block<'a>(&mut self, src: &'a [u8]) -> Result<(&'a [u8], Block<'a>), PcapError> {
-        // Read next Block
-        match self.state.section.endianness {
-            Endianness::Big => {
-                let (rem, raw_block) = self.next_raw_block_inner::<BigEndian>(src)?;
-                let block = raw_block.try_into_block::<BigEndian>(&self.state)?;
-                Ok((rem, block))
-            },
-            Endianness::Little => {
-                let (rem, raw_block) = self.next_raw_block_inner::<LittleEndian>(src)?;
-                let block = raw_block.try_into_block::<LittleEndian>(&self.state)?;
-                Ok((rem, block))
-            },
-        }
+        // Read next RawBlock and convert it to block
+        self.next_raw_block(src).and_then(|(rem, raw)| {
+            let state = &self.state;
+            raw.try_into_block(state).map(|block| (rem, block))
+        })
     }
 
     /// Returns the remainder and the next [`RawBlock`].
+    /// More permissive than [`Self::next_block`].
+    ///
+    /// A [`RawBlock`] can be validated using [`RawBlock::try_into_block`].
+    ///
+    /// # Errors
+    /// - Only [`PcapError::IncompleteBuffer`] is recoverable (by loading more data).
+    /// - All other errors will prevent the parser from advancing further.
     pub fn next_raw_block<'a>(&mut self, src: &'a [u8]) -> Result<(&'a [u8], RawBlock<'a>), PcapError> {
         // Read next Block
         match self.state.section.endianness {
@@ -100,6 +103,11 @@ impl PcapNgParser {
         let (rem, raw_block) = RawBlock::from_slice::<B>(src)?;
         self.state.update_from_raw_block::<B>(&raw_block)?;
         Ok((rem, raw_block))
+    }
+
+    /// Returns the current [`PcapNgState`].
+    pub fn state(&self) -> &PcapNgState {
+        &self.state
     }
 
     /// Returns the current [`SectionHeaderBlock`].

--- a/src/pcapng/reader.rs
+++ b/src/pcapng/reader.rs
@@ -8,7 +8,6 @@ use super::{PcapNgParser, PcapNgState};
 use crate::errors::PcapError;
 use crate::read_buffer::ReadBuffer;
 
-
 /// Reads a PcapNg from a reader.
 ///
 /// # Example
@@ -23,7 +22,7 @@ use crate::read_buffer::ReadBuffer;
 /// // Read test.pcapng
 /// while let Some(block) = pcapng_reader.next_block() {
 ///     //Check if there is no error
-///     let block = block.unwrap();
+///     let (block, state) = block.unwrap();
 ///
 ///     //Do something
 /// }
@@ -44,15 +43,22 @@ impl<R: Read> PcapNgReader<R> {
     }
 
     /// Returns the next [`Block`] and the current [`PcapNgState`].
-    pub fn next_block_and_state(&mut self) -> Option<Result<(Block<'_>, &PcapNgState), PcapError>> {
+    /// [`None`] means that the reader have reached the EoF.
+    /// Won't advance the reader past any malformed packets.
+    ///
+    /// # Errors
+    /// - Only some variants of [`PcapError::IoError`] are directly recoverable.
+    /// - Other errors will prevent the reader from advancing further.
+    ///   Some can be recovered by calling [`Self::next_raw_block`].
+    pub fn next_block<'a>(&'a mut self) -> Option<Result<(Block<'a>, &'a PcapNgState), PcapError>> {
         match self.reader.has_data_left() {
             Ok(has_data) => {
                 if has_data {
                     // # SAFETY
                     // Block must NOT contain a mutable reference to the state.
-                    // Keep the annotations to be sure that only the lifetime is trnasmuted.
+                    // Keep the annotations to be sure that only the lifetime is transmuted.
                     let res: Result<Block<'_>, PcapError> = self.reader.parse_with(|src| self.parser.next_block(src));
-                    let res: Result<Block<'_>, PcapError> = unsafe {std::mem::transmute(res)};
+                    let res: Result<Block<'_>, PcapError> = unsafe { std::mem::transmute(res) };
 
                     let state = &self.parser.state;
 
@@ -65,23 +71,29 @@ impl<R: Read> PcapNgReader<R> {
         }
     }
 
-    /// Returns the next [`Block`].
-    pub fn next_block(&mut self) -> Option<Result<Block<'_>, PcapError>> {
-        match self.next_block_and_state() {
-            None => None,
-            Some(Ok((block, _state))) => Some(Ok(block)),
-            Some(Err(e)) => Some(Err(e))
-        }
-    }
-
-    /// Returns the next [`RawBlock`].
-    pub fn next_raw_block(&mut self) -> Option<Result<RawBlock<'_>, PcapError>> {
+    /// Returns the next [`RawBlock`] and the current [`PcapNgState`].
+    /// [`None`] means that the reader have reached the EoF.
+    /// More permissive than [`Self::next_block`].
+    ///
+    /// A [`RawBlock`] can be validated using [`RawBlock::try_into_block`].
+    ///
+    /// # Errors
+    /// - Only some variants of [`PcapError::IoError`] are directly recoverable.
+    /// - All other errors will prevent the reader from advancing further.
+    pub fn next_raw_block<'a>(&'a mut self) -> Option<Result<(RawBlock<'a>, &'a PcapNgState), PcapError>> {
         match self.reader.has_data_left() {
             Ok(has_data) => {
                 if has_data {
-                    Some(self.reader.parse_with(|src| self.parser.next_raw_block(src)))
-                }
-                else {
+                    // # SAFETY
+                    // Block must NOT contain a mutable reference to the state.
+                    // Keep the annotations to be sure that only the lifetime is transmuted.
+                    let res: Result<RawBlock<'_>, PcapError> = self.reader.parse_with(|src| self.parser.next_raw_block(src));
+                    let res: Result<RawBlock<'_>, PcapError> = unsafe { std::mem::transmute(res) };
+
+                    let state = &self.parser.state;
+
+                    Some(res.map(|blk| (blk, state)))
+                } else {
                     None
                 }
             },

--- a/src/pcapng/state.rs
+++ b/src/pcapng/state.rs
@@ -74,7 +74,7 @@ impl PcapNgState {
     pub fn update_from_raw_block<B: ByteOrder>(&mut self, raw_block: &RawBlock) -> Result<(), PcapError> {
         match raw_block.type_ {
             SECTION_HEADER_BLOCK | INTERFACE_DESCRIPTION_BLOCK => {
-                let block = raw_block.clone().try_into_block::<B>(self)?;
+                let block = raw_block.clone().try_into_block_with_byteorder::<B>(self)?;
                 self.update_from_block(&block)
             },
             _ => Ok(())

--- a/src/pcapng/writer.rs
+++ b/src/pcapng/writer.rs
@@ -26,7 +26,7 @@ use crate::{Endianness, PcapError, PcapResult};
 /// // Read test.pcapng
 /// while let Some(block) = pcapng_reader.next_block() {
 ///     // Check if there is no error
-///     let block = block.unwrap();
+///     let (block, _) = block.unwrap();
 ///
 ///     // Write back parsed Block
 ///     pcapng_writer.write_block(&block).unwrap();

--- a/tests/pcap/mod.rs
+++ b/tests/pcap/mod.rs
@@ -135,7 +135,11 @@ fn infinite_loop() {
     let mut pcap_reader = PcapReader::new(&data[..]).unwrap();
 
     let mut i = 0;
-    while pcap_reader.next_packet().is_some() {
+    while let Some(pkt) = pcap_reader.next_packet() {
+        let Ok(_) = pkt else {
+            break;
+        };
+        
         if i > 18 {
             panic!("infinite loop detected");
         }

--- a/tests/pcapng/mod.rs
+++ b/tests/pcapng/mod.rs
@@ -58,7 +58,7 @@ fn writer() {
 
         let mut idx = 0;
         while let Some(block) = pcapng_reader.next_block() {
-            let block = block.unwrap();
+            let (block, _) = block.unwrap();
             pcapng_writer
                 .write_block(&block)
                 .unwrap_or_else(|_| panic!("Error writing block, file: {entry:?}, block n°{idx}, block: {block:?}"));
@@ -74,8 +74,8 @@ fn writer() {
 
             let mut idx = 0;
             while let (Some(expected), Some(actual)) = (expected_reader.next_block(), actual_reader.next_block()) {
-                let expected = expected.unwrap();
-                let actual = actual.unwrap();
+                let (expected, _) = expected.unwrap();
+                let (actual, _) = actual.unwrap();
 
                 if expected != actual {
                     assert_eq!(expected, actual, "Pcap written != pcap read, file: {entry:?}, block n°{idx}")
@@ -350,7 +350,7 @@ fn test_stateful_custom_block() {
         .expect("Failed to create reader");
 
     // Read the first block, which should be the interface description
-    let first_block = pcapng_reader
+    let (first_block, _) = pcapng_reader
         .next_block()
         .expect("No first block from reader")
         .expect("Failed to get first block");
@@ -358,8 +358,8 @@ fn test_stateful_custom_block() {
     assert!(matches!(first_block, Block::InterfaceDescription(_)));
 
     // Read the next block, which should be our custom block
-    let (read_block_enum, reader_state) = pcapng_reader
-        .next_block_and_state()
+    let (read_block_enum, reader_state)  = pcapng_reader
+        .next_block()
         .expect("No second block from reader")
         .expect("Failed to get next block");
 
@@ -384,7 +384,7 @@ fn test_stateful_custom_block() {
 
     // Read the last block, which should be our packet block
     let (last_block, reader_state) = pcapng_reader
-        .next_block_and_state()
+        .next_block()
         .expect("No third block from reader")
         .expect("Failed to get next block");
 

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -16,7 +16,7 @@ fn timestamp_resolution() {
 
     let mut i = 0;
     while let Some(block) = pcapng_reader.next_block() {
-        let block = block.unwrap_or_else(|_| panic!("Error on block {i}"));
+        let (block, _) = block.unwrap_or_else(|_| panic!("Error on block {i}"));
         
         match i {
             0 => {


### PR DESCRIPTION
- stop advancing past malformed packets in reader flows and update examples/tests
- make pcapng reader methods return the parsed block together with the current state
- derive raw block conversion byte order from PcapNgState and expose parser state access
- document recoverable parse errors for pcap and pcapng parsers/readers