### PR TITLE
Annotate minimum supported Rust version as 1.87

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ edition = "2021"
 version = "3.0.0-rc.2"
 authors = ["Courvoif <courvoif@pm.me>"]
 description = "A crate to parse, read and write Pcap and PcapNg"
+rust-version = "1.87"
 
 license = "MIT"
 documentation = "https://docs.rs/pcap-file/"


### PR DESCRIPTION
Fixes #61.