### PR TITLE
Refactor pcapng custom payload API

### DIFF
--- a/src/pcapng/blocks/custom.rs
+++ b/src/pcapng/blocks/custom.rs
@@ -9,9 +9,159 @@ use byteorder_slice::byteorder::{ReadBytesExt, WriteBytesExt};
 use thiserror::Error;
 
 use super::block_common::{Block, PcapNgBlock};
-use super::opt_common::CustomBinaryOption;
-use crate::pcapng::PcapNgState;
+use crate::pcapng::blocks::opt_common::CommonOption;
 use crate::pcapng::errors::{BlockContentParseError, PcapNgWriteError};
+use crate::pcapng::{OptionEntryError, PcapNgState};
+
+/* ----- traits for Custom Payload ----- */
+
+/// Common interface for copiable custom block and custom option payloads.
+pub trait CustomPayloadCopiable<'a> {
+    /// Private Enterprise Number of the entity which defined this payload format.
+    const PEN: u32;
+
+    /// Error returned by [`CustomPayloadCopiable::from_slice()`].
+    type FromSliceError: Error + Sync + Send + 'static;
+
+    /// Error returned by [`CustomPayloadCopiable::write_to()`].
+    type WriteToError: Error + Sync + Send + 'static;
+
+    /// Try to parse this payload from a slice.
+    fn from_slice(slice: &'a [u8]) -> Result<Option<Self>, Self::FromSliceError>
+    where
+        Self: Sized;
+
+    /// Write this payload into a writer.
+    fn write_to<W: Write>(&self, writer: &mut W) -> Result<(), Self::WriteToError>;
+
+    /// Serialize this payload into bytes.
+    ///
+    /// # Important
+    /// Do not override.
+    fn to_bytes(&self) -> Result<Vec<u8>, CustomError>
+    where
+        Self: Sized,
+    {
+        let mut data = Vec::new();
+        self.write_to(&mut data).map_err(|e| CustomError { pen: Self::PEN, src: e.into() })?;
+        Ok(data)
+    }
+}
+
+/// Common interface for non-copiable custom block and custom option payloads.
+pub trait CustomPayloadNonCopiable<'a> {
+    /// Private Enterprise Number of the entity which defined this payload format.
+    const PEN: u32;
+
+    /// State that may be required to parse/write the payload.
+    type State;
+
+    /// Error returned by [`CustomPayloadNonCopiable::from_slice()`].
+    type FromSliceError: Error + Sync + Send + 'static;
+
+    /// Error returned by [`CustomPayloadNonCopiable::write_to()`].
+    type WriteToError: Error + Sync + Send + 'static;
+
+    /// Try to parse this payload from a slice.
+    fn from_slice(state: &Self::State, slice: &'a [u8]) -> Result<Option<Self>, Self::FromSliceError>
+    where
+        Self: Sized;
+
+    /// Write this payload into a writer.
+    fn write_to<W: Write>(&self, state: &Self::State, writer: &mut W) -> Result<(), Self::WriteToError>;
+
+    /// Serialize this payload into bytes.
+    ///
+    /// # Important
+    /// Do not override.
+    fn to_bytes(&self, state: &Self::State) -> Result<Vec<u8>, CustomError>
+    where
+        Self: Sized,
+    {
+        let mut data = Vec::new();
+        self.write_to(state, &mut data).map_err(|e| CustomError { pen: Self::PEN, src: e.into() })?;
+        Ok(data)
+    }
+}
+
+/// Common interface for custom block payloads.
+///
+/// # Important
+/// Any implementor must also implements [`CustomPayloadCopiable`] and/or [`CustomPayloadNonCopiable`].
+pub trait CustomPayloadBlock<'a> {
+    /// Convert this payload into a copiable [`CustomBlock`].
+    ///
+    /// # Important
+    /// Do not override.
+    fn into_custom_block_copiable(self) -> Result<CustomBlock<'a, true>, CustomError>
+    where
+        Self: Sized,
+        Self: CustomPayloadCopiable<'a>,
+    {
+        let data = self.to_bytes()?;
+        Ok(CustomBlock { pen: Self::PEN, payload: Cow::Owned(data) })
+    }
+
+    /// Convert this payload into a non-copiable [`CustomBlock`].
+    ///
+    /// # Important
+    /// Do not override.
+    fn into_custom_block_non_copiable(self, state: &Self::State) -> Result<CustomBlock<'a, false>, CustomError>
+    where
+        Self: Sized,
+        Self: CustomPayloadNonCopiable<'a>,
+    {
+        let data = self.to_bytes(state)?;
+        Ok(CustomBlock { pen: Self::PEN, payload: Cow::Owned(data) })
+    }
+}
+
+/// Common interface for custom option payloads.
+///
+/// # Important
+/// Any implementor must also implements [`CustomPayloadCopiable`] and/or [`CustomPayloadNonCopiable`].
+pub trait CustomPayloadOption<'a> {
+    /// Convert this payload into a copiable [`CustomBinaryOption`].
+    ///
+    /// # Important
+    /// Do not override.
+    fn into_custom_binary_option_copiable(self) -> Result<CustomBinaryOption<'a, true>, CustomError>
+    where
+        Self: Sized,
+        Self: CustomPayloadCopiable<'a>,
+    {
+        let data = self.to_bytes()?;
+        Ok(CustomBinaryOption { pen: Self::PEN, value: Cow::Owned(data) })
+    }
+
+    /// Convert this payload into a non-copiable [`CustomBinaryOption`].
+    ///
+    /// # Important
+    /// Do not override.
+    fn into_custom_binary_option_non_copiable(self, state: &Self::State) -> Result<CustomBinaryOption<'a, false>, CustomError>
+    where
+        Self: Sized,
+        Self: CustomPayloadNonCopiable<'a>,
+    {
+        let data = self.to_bytes(state)?;
+        Ok(CustomBinaryOption { pen: Self::PEN, value: Cow::Owned(data) })
+    }
+}
+
+/* ----- Custom Error ----- */
+
+/// Error in custom conversion
+#[derive(Debug, Error)]
+#[error("Error in custom conversion for PEN {pen:#X}")]
+pub struct CustomError {
+    /// Pen of the custom block/option
+    pub pen: u32,
+    /// Source of the error
+    #[source]
+    pub src: Box<dyn Error + Sync + Send + 'static>,
+}
+
+/* ----- struct CustomBlock ----- */
 
 /// Custom block
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -22,9 +172,22 @@ pub struct CustomBlock<'a, const COPIABLE: bool> {
     pub payload: Cow<'a, [u8]>,
 }
 
+impl<'a, const COPIABLE: bool> CustomBlock<'a, COPIABLE> {
+    // The into_owned method must be implemented manually,
+    // since derive_into_owned can't handle the const generic.
+
+    /// Returns a version of self with all fields converted to owning versions.
+    pub fn into_owned(self) -> CustomBlock<'static, COPIABLE> {
+        CustomBlock { pen: self.pen, payload: Cow::Owned(self.payload.into_owned()) }
+    }
+}
+
 impl<'a> CustomBlock<'a, true> {
-    /// Converts this block's payload into a type that implements [`CustomCopiable`].
-    pub fn interpret<T: CustomCopiable<'a>>(&'a self) -> Result<Option<T>, CustomError> {
+    /// Converts this block's payload into a copiable custom payload type.
+    pub fn interpret<T>(&'a self) -> Result<Option<T>, CustomError>
+    where
+        T: CustomPayloadCopiable<'a> + CustomPayloadBlock<'a>,
+    {
         if self.pen != T::PEN {
             return Ok(None);
         }
@@ -34,23 +197,16 @@ impl<'a> CustomBlock<'a, true> {
 }
 
 impl<'a> CustomBlock<'a, false> {
-    /// Converts this block's payload into a type that implements [`CustomNonCopiable`].
-    pub fn interpret<T: CustomNonCopiable<'a>>(&'a self, state: &T::State) -> Result<Option<T>, CustomError> {
+    /// Converts this block's payload into a non-copiable custom payload type.
+    pub fn interpret<T>(&'a self, state: &T::State) -> Result<Option<T>, CustomError>
+    where
+        T: CustomPayloadNonCopiable<'a> + CustomPayloadBlock<'a>,
+    {
         if self.pen != T::PEN {
             return Ok(None);
         }
 
         T::from_slice(state, &self.payload).map_err(|e| CustomError { pen: T::PEN, src: e.into() })
-    }
-}
-
-impl<const COPIABLE: bool> CustomBlock<'_, COPIABLE> {
-    // The into_owned method must be implemented manually,
-    // since derive_into_owned can't handle the const generic.
-
-    /// Returns a version of self with all fields converted to owning versions.
-    pub fn into_owned(self) -> CustomBlock<'static, COPIABLE> {
-        CustomBlock { pen: self.pen, payload: Cow::Owned(self.payload.into_owned()) }
     }
 }
 
@@ -82,106 +238,90 @@ impl<'a, const COPIABLE: bool> PcapNgBlock<'a> for CustomBlock<'a, COPIABLE> {
     }
 }
 
-/* ----- Custom Error ----- */
+/* ----- struct CustomBinaryOption ----- */
 
-/// Error in custom conversion
-#[derive(Debug, Error)]
-#[error("Error in custom conversion for PEN {pen:#X}")]
-pub struct CustomError {
-    /// Pen of the custom block/option
+/// Custom binary option
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct CustomBinaryOption<'a, const COPIABLE: bool> {
+    /// Option PEN identifier
     pub pen: u32,
-    /// Source of the error
-    #[source]
-    pub src: Box<dyn Error + Sync + Send + 'static>,
+    /// Option value
+    pub value: Cow<'a, [u8]>,
 }
 
-/* ----- trait CustomCopiable ----- */
-
-/// Common interface for copiable custom block payloads
-pub trait CustomCopiable<'a> {
-    /// Private Enterprise Number of the entity which defined this payload format.
-    const PEN: u32;
-
-    /// Error returned by [`CustomCopiable::from_slice()`]
-    type FromSliceError: Error + Sync + Send + 'static;
-
-    /// Error returned by [`CustomCopiable::write_to()`]
-    type WriteToError: Error + Sync + Send + 'static;
-
-    /// Try to parse this payload from a slice.
-    fn from_slice(slice: &'a [u8]) -> Result<Option<Self>, Self::FromSliceError>
-    where
-        Self: Sized;
-
-    /// Write this payload into a writer.
-    fn write_to<W: Write>(&self, writer: &mut W) -> Result<(), Self::WriteToError>;
-
-    /// Convert this block into a copiable [`CustomBlock`]
-    fn into_custom_block(self) -> Result<CustomBlock<'a, true>, CustomError>
-    where
-        Self: Sized,
-    {
-        let mut data = Vec::new();
-        self.write_to(&mut data).map_err(|e| CustomError { pen: Self::PEN, src: e.into() })?;
-
-        Ok(CustomBlock { pen: Self::PEN, payload: Cow::Owned(data) })
+impl<'a, const COPIABLE: bool> CustomBinaryOption<'a, COPIABLE> {
+    /// Parse an [`CustomBinaryOption`] from a slice
+    pub fn from_slice<B: ByteOrder>(mut src: &'a [u8]) -> Result<Self, OptionEntryError> {
+        let pen = src.read_u32::<B>().map_err(|_| OptionEntryError::WrongSize { expected: 4, actual: src.len() })?;
+        let opt = CustomBinaryOption { pen, value: Cow::Borrowed(src) };
+        Ok(opt)
     }
 
-    /// Convert this block into a copiable [`CustomBinaryOption`]
-    fn into_custom_option(self) -> Result<CustomBinaryOption<'a, true>, CustomError>
-    where
-        Self: Sized,
-    {
-        let mut data = Vec::new();
-        self.write_to(&mut data).map_err(|e| CustomError { pen: Self::PEN, src: e.into() })?;
-
-        Ok(CustomBinaryOption { pen: Self::PEN, value: Cow::Owned(data) })
+    /// Returns a version of self with all fields converted to owning versions.
+    pub fn into_owned(self) -> CustomBinaryOption<'static, COPIABLE> {
+        CustomBinaryOption { pen: self.pen, value: Cow::Owned(self.value.into_owned()) }
     }
 }
 
-/* ----- trait CustomNonCopiable ----- */
-
-/// Common interface for non-copiable custom block payloads
-pub trait CustomNonCopiable<'a> {
-    /// Private Enterprise Number of the entity which defined this payload format.
-    const PEN: u32;
-
-    /// State that may be required to parse/write the block.
-    type State;
-
-    /// Error returned by [`CustomNonCopiable::from_slice()`]
-    type FromSliceError: Error + Sync + Send + 'static;
-
-    /// Error returned by [`CustomNonCopiable::write_to()`]
-    type WriteToError: Error + Sync + Send + 'static;
-
-    /// Try to parse this payload from a slice.
-    fn from_slice(state: &Self::State, slice: &'a [u8]) -> Result<Option<Self>, Self::FromSliceError>
+impl<'a> CustomBinaryOption<'a, true> {
+    /// Converts this option's value into a copiable custom payload type.
+    pub fn interpret<T>(&'a self) -> Result<Option<T>, CustomError>
     where
-        Self: Sized;
-
-    /// Write this payload into a writer.
-    fn write_to<W: Write>(&self, state: &Self::State, writer: &mut W) -> Result<(), Self::WriteToError>;
-
-    /// Convert this block into a non-copiable [`CustomBlock`]
-    fn into_custom_block(self, state: &Self::State) -> Result<CustomBlock<'a, false>, CustomError>
-    where
-        Self: Sized,
+        T: CustomPayloadCopiable<'a> + CustomPayloadOption<'a>,
     {
-        let mut data = Vec::new();
-        self.write_to(state, &mut data).map_err(|e| CustomError { pen: Self::PEN, src: e.into() })?;
+        if self.pen != T::PEN {
+            return Ok(None);
+        }
 
-        Ok(CustomBlock { pen: Self::PEN, payload: Cow::Owned(data) })
+        T::from_slice(&self.value).map_err(|e| CustomError { pen: T::PEN, src: e.into() })
     }
 
-    /// Convert this block into a non-copiable [`CustomBinaryOption`]
-    fn into_custom_option(self, state: &Self::State) -> Result<CustomBinaryOption<'a, false>, CustomError>
-    where
-        Self: Sized,
-    {
-        let mut data = Vec::new();
-        self.write_to(state, &mut data).map_err(|e| CustomError { pen: Self::PEN, src: e.into() })?;
+    /// Converts this option into a [`CommonOption`].
+    pub fn into_common_option(self) -> CommonOption<'a> {
+        CommonOption::CustomBinaryCopiable(self)
+    }
+}
 
-        Ok(CustomBinaryOption { pen: Self::PEN, value: Cow::Owned(data) })
+impl<'a> CustomBinaryOption<'a, false> {
+    /// Converts this option's value into a non-copiable custom payload type.
+    pub fn interpret<T>(&'a self, state: &T::State) -> Result<Option<T>, CustomError>
+    where
+        T: CustomPayloadNonCopiable<'a> + CustomPayloadOption<'a>,
+    {
+        if self.pen != T::PEN {
+            return Ok(None);
+        }
+
+        T::from_slice(state, &self.value).map_err(|e| CustomError { pen: T::PEN, src: e.into() })
+    }
+
+    /// Converts this option into a [`CommonOption`].
+    pub fn into_common_option(self) -> CommonOption<'a> {
+        CommonOption::CustomBinaryNonCopiable(self)
+    }
+}
+
+/* ----- struct CustomUtf8Option ----- */
+
+/// Custom string (UTF-8) option
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct CustomUtf8Option<'a, const COPIABLE: bool> {
+    /// Option PEN identifier
+    pub pen: u32,
+    /// Option value
+    pub value: Cow<'a, str>,
+}
+
+impl<'a, const COPIABLE: bool> CustomUtf8Option<'a, COPIABLE> {
+    /// Parse a [`CustomUtf8Option`] from a slice
+    pub fn from_slice<B: ByteOrder>(mut src: &'a [u8]) -> Result<Self, OptionEntryError> {
+        let pen = src.read_u32::<B>().map_err(|_| OptionEntryError::WrongSize { expected: 4, actual: src.len() })?;
+        let opt = CustomUtf8Option { pen, value: Cow::Borrowed(std::str::from_utf8(src)?) };
+        Ok(opt)
+    }
+
+    /// Returns a version of self with all fields converted to owning versions.
+    pub fn into_owned(self) -> CustomUtf8Option<'static, COPIABLE> {
+        CustomUtf8Option { pen: self.pen, value: Cow::Owned(self.value.into_owned()) }
     }
 }

--- a/src/pcapng/blocks/opt_common.rs
+++ b/src/pcapng/blocks/opt_common.rs
@@ -8,7 +8,7 @@ use byteorder_slice::byteorder::WriteBytesExt;
 use byteorder_slice::result::ReadSlice;
 use derive_into_owned::IntoOwned;
 
-use crate::pcapng::blocks::custom::{CustomCopiable, CustomError, CustomNonCopiable};
+use crate::pcapng::blocks::custom::{CustomBinaryOption, CustomUtf8Option};
 use crate::pcapng::errors::{OptionEntryError, OptionParseError, PcapNgWriteError};
 use crate::pcapng::{ContentValidationError, PcapNgState};
 
@@ -77,38 +77,6 @@ impl<'a> CommonOption<'a> {
             CUSTOM_BINARY_OPTION_NON_COPIABLE => "CustomBinaryNonCopiable",
             _ => "Unknown",
         }
-    }
-}
-
-impl<'a> CustomBinaryOption<'a, true> {
-    /// Converts this option's value into a type that implements [`CustomCopiable`].
-    pub fn interpret<T: CustomCopiable<'a>>(&'a self) -> Result<Option<T>, CustomError> {
-        if self.pen != T::PEN {
-            return Ok(None);
-        }
-
-        T::from_slice(&self.value).map_err(|e| CustomError { pen: T::PEN, src: e.into() })
-    }
-
-    /// Converts this option into a [`CommonOption`].
-    pub fn into_common_option(self) -> CommonOption<'a> {
-        CommonOption::CustomBinaryCopiable(self)
-    }
-}
-
-impl<'a> CustomBinaryOption<'a, false> {
-    /// Converts this option's value into a type that implements [`CustomNonCopiable`].
-    pub fn interpret<T: CustomNonCopiable<'a>>(&'a self, state: &T::State) -> Result<Option<T>, CustomError> {
-        if self.pen != T::PEN {
-            return Ok(None);
-        }
-
-        T::from_slice(state, &self.value).map_err(|e| CustomError { pen: T::PEN, src: e.into() })
-    }
-
-    /// Converts this option into a [`CommonOption`].
-    pub fn into_common_option(self) -> CommonOption<'a> {
-        CommonOption::CustomBinaryNonCopiable(self)
     }
 }
 
@@ -224,52 +192,6 @@ impl<'a> UnknownOption<'a> {
     /// Creates a new [`UnknownOption`]
     pub fn new(code: u16, value: &'a [u8]) -> Self {
         UnknownOption { code, value: Cow::Borrowed(value) }
-    }
-}
-
-/// Custom binary option
-#[derive(Clone, Debug, Eq, PartialEq)]
-pub struct CustomBinaryOption<'a, const COPIABLE: bool> {
-    /// Option PEN identifier
-    pub pen: u32,
-    /// Option value
-    pub value: Cow<'a, [u8]>,
-}
-
-impl<'a, const COPIABLE: bool> CustomBinaryOption<'a, COPIABLE> {
-    /// Parse an [`CustomBinaryOption`] from a slice
-    pub fn from_slice<B: ByteOrder>(mut src: &'a [u8]) -> Result<Self, OptionEntryError> {
-        let pen = src.read_u32::<B>().map_err(|_| OptionEntryError::WrongSize { expected: 4, actual: src.len() })?;
-        let opt = CustomBinaryOption { pen, value: Cow::Borrowed(src) };
-        Ok(opt)
-    }
-
-    /// Returns a version of self with all fields converted to owning versions.
-    pub fn into_owned(self) -> CustomBinaryOption<'static, COPIABLE> {
-        CustomBinaryOption { pen: self.pen, value: Cow::Owned(self.value.into_owned()) }
-    }
-}
-
-/// Custom string (UTF-8) option
-#[derive(Clone, Debug, Eq, PartialEq)]
-pub struct CustomUtf8Option<'a, const COPIABLE: bool> {
-    /// Option PEN identifier
-    pub pen: u32,
-    /// Option value
-    pub value: Cow<'a, str>,
-}
-
-impl<'a, const COPIABLE: bool> CustomUtf8Option<'a, COPIABLE> {
-    /// Parse a [`CustomUtf8Option`] from a slice
-    pub fn from_slice<B: ByteOrder>(mut src: &'a [u8]) -> Result<Self, OptionEntryError> {
-        let pen = src.read_u32::<B>().map_err(|_| OptionEntryError::WrongSize { expected: 4, actual: src.len() })?;
-        let opt = CustomUtf8Option { pen, value: Cow::Borrowed(std::str::from_utf8(src)?) };
-        Ok(opt)
-    }
-
-    /// Returns a version of self with all fields converted to owning versions.
-    pub fn into_owned(self) -> CustomUtf8Option<'static, COPIABLE> {
-        CustomUtf8Option { pen: self.pen, value: Cow::Owned(self.value.into_owned()) }
     }
 }
 

--- a/tests/pcapng/mod.rs
+++ b/tests/pcapng/mod.rs
@@ -106,7 +106,7 @@ fn test_custom_block() {
     }
 
     // 2. Implement the required traits for the custom payload
-    impl CustomCopiable<'_> for MyCustomPayload {
+    impl CustomPayloadCopiable<'_> for MyCustomPayload {
         // A unique PEN for our test block
         const PEN: u32 = 70000;
         type WriteToError = IoError;
@@ -124,13 +124,16 @@ fn test_custom_block() {
         }
     }
 
+    impl CustomPayloadBlock<'_> for MyCustomPayload {}
+    impl CustomPayloadOption<'_> for MyCustomPayload {}
+
     let original_payload = MyCustomPayload { magic_number: 0xDEADBEEFCAFED00D };
 
     let section = SectionHeaderBlock {
         options: vec![SectionHeaderOption::Common(
             original_payload
                 .clone()
-                .into_custom_option()
+                .into_custom_binary_option_copiable()
                 .expect("Failed to encode custom option")
                 .into_common_option(),
         )],
@@ -140,7 +143,7 @@ fn test_custom_block() {
     let mut buffer = Vec::new();
     let mut pcapng_writer = PcapNgWriter::with_section_header(&mut buffer, section).expect("Failed to create writer");
 
-    let block_to_write = original_payload.clone().into_custom_block().expect("Failed to encode custom block").into_block();
+    let block_to_write = original_payload.clone().into_custom_block_copiable().expect("Failed to encode custom block").into_block();
 
     pcapng_writer.write_block(&block_to_write).expect("Failed to write custom block");
 
@@ -238,7 +241,7 @@ fn writer_handles_section_endianness_switch() {
 
     let (rem, block) = parser.next_block(rem).unwrap();
     assert_eq!(block, Block::InterfaceDescription(big_interface));
-    
+
     assert!(rem.is_empty());
 }
 
@@ -273,7 +276,7 @@ fn test_stateful_custom_block() {
     }
 
     // 2. Implement the required traits for the custom payload
-    impl CustomNonCopiable<'_> for MyStatefulPayload {
+    impl CustomPayloadNonCopiable<'_> for MyStatefulPayload {
         // A unique PEN for our test block
         const PEN: u32 = 70000;
 
@@ -320,6 +323,9 @@ fn test_stateful_custom_block() {
         }
     }
 
+    impl CustomPayloadBlock<'_> for MyStatefulPayload {}
+    impl CustomPayloadOption<'_> for MyStatefulPayload {}
+
     let original_payload = MyStatefulPayload { magic_number: 0xDEADBEEFCAFED00D, interface_id: 0, timestamp: 123456789 };
 
     let mut buffer = Vec::new();
@@ -338,7 +344,7 @@ fn test_stateful_custom_block() {
 
     let block_to_write = original_payload
         .clone()
-        .into_custom_block(pcapng_writer.state())
+        .into_custom_block_non_copiable(pcapng_writer.state())
         .expect("Failed to encode custom block")
         .into_block();
 
@@ -352,7 +358,7 @@ fn test_stateful_custom_block() {
         options: vec![EnhancedPacketOption::Common(
             original_payload
                 .clone()
-                .into_custom_option(pcapng_writer.state())
+                .into_custom_binary_option_non_copiable(pcapng_writer.state())
                 .expect("Failed to encode custom option")
                 .into_common_option(),
         )],


### PR DESCRIPTION
- Move custom binary and UTF-8 option types into the custom block module.
- Add block/option capability traits.
- Expose conversion helpers for copiable and non-copiable custom blocks and binary options.
- Update custom payload tests to cover the new API for both stateless copiable payloads and stateful non-copiable payloads.