### PR TITLE
Unify read buffer parsing paths

### DIFF
--- a/src/pcap/reader.rs
+++ b/src/pcap/reader.rs
@@ -43,7 +43,7 @@ impl<R: Read> PcapReader<R> {
     /// The underlying data are not readable.
     pub fn new(reader: R) -> Result<PcapReader<R>, PcapReadError> {
         let mut reader = ReadBuffer::new(reader);
-        let parser = reader.parse_with2(PcapParser::new)?;
+        let parser = reader.parse_with(PcapParser::new)?;
 
         Ok(PcapReader { parser, reader })
     }
@@ -64,7 +64,7 @@ impl<R: Read> PcapReader<R> {
         match self.reader.has_data_left() {
             Ok(has_data) => {
                 if has_data {
-                    Some(self.reader.parse_with2(|src| self.parser.next_packet(src)))
+                    Some(self.reader.parse_with(|src| self.parser.next_packet(src)))
                 } else {
                     None
                 }
@@ -86,7 +86,7 @@ impl<R: Read> PcapReader<R> {
         match self.reader.has_data_left() {
             Ok(has_data) => {
                 if has_data {
-                    Some(self.reader.parse_with2(|src| self.parser.next_raw_packet(src)))
+                    Some(self.reader.parse_with(|src| self.parser.next_raw_packet(src)))
                 } else {
                     None
                 }

--- a/src/read_buffer.rs
+++ b/src/read_buffer.rs
@@ -5,6 +5,8 @@ use crate::{
     pcapng::errors::{PcapNgParseError, PcapNgReadError},
 };
 
+/* ----- ReadBuffer ----- */
+
 /// Internal structure that bufferize its input and allow to parse element from its buffer.
 #[derive(Debug)]
 pub(crate) struct ReadBuffer<R: Read> {
@@ -20,7 +22,6 @@ pub(crate) struct ReadBuffer<R: Read> {
     pub(crate) bytes_used: u64,
 }
 
-// TODO: Unify parse_with and parse_with-2
 impl<R: Read> ReadBuffer<R> {
     /// Creates a new ReadBuffer with capacity of 8_000_000
     pub fn new(reader: R) -> Self {
@@ -37,11 +38,12 @@ impl<R: Read> ReadBuffer<R> {
     /// Safety
     ///
     /// The parser must NOT keep a reference to the buffer in input.
-    pub fn parse_with<'a, 'b: 'a, 'c: 'a, F, O>(&'c mut self, mut parser: F) -> Result<O, PcapNgReadError>
+    pub fn parse_with<'a, 'b: 'a, 'c: 'a, F, O, E>(&'c mut self, mut parser: F) -> Result<O, E::ReadError>
     where
-        F: FnMut(&'a [u8]) -> Result<(&'a [u8], O), PcapNgParseError>,
+        F: FnMut(&'a [u8]) -> Result<(&'a [u8], O), E>,
         F: 'b,
         O: 'a,
+        E: ReadBufferParseError,
     {
         loop {
             let buf = &self.buffer[self.pos..self.len];
@@ -55,59 +57,19 @@ impl<R: Read> ReadBuffer<R> {
                     return Ok(value);
                 },
 
-                Err(PcapNgParseError::IncompleteBuffer(_, _)) => {
+                Err(e) if e.is_incomplete() => {
                     // The parsed data len should never be more than the buffer capacity
                     if buf.len() == self.buffer.len() {
-                        return Err(PcapNgReadError::Io(Error::from(ErrorKind::UnexpectedEof)));
+                        return Err(E::from_io(Error::from(ErrorKind::UnexpectedEof)));
                     }
 
-                    let nb_read = self.fill_buf().map_err(PcapNgReadError::Io)?;
+                    let nb_read = self.fill_buf().map_err(E::from_io)?;
                     if nb_read == 0 {
-                        return Err(PcapNgReadError::Io(Error::from(ErrorKind::UnexpectedEof)));
+                        return Err(E::from_io(Error::from(ErrorKind::UnexpectedEof)));
                     }
                 },
 
-                Err(e) => return Err(e.into()),
-            }
-        }
-    }
-
-    /// Parse data from the internal buffer
-    ///
-    /// Safety
-    ///
-    /// The parser must NOT keep a reference to the buffer in input.
-    pub fn parse_with2<'a, 'b: 'a, 'c: 'a, F, O>(&'c mut self, mut parser: F) -> Result<O, PcapReadError>
-    where
-        F: FnMut(&'a [u8]) -> Result<(&'a [u8], O), PcapParseError>,
-        F: 'b,
-        O: 'a,
-    {
-        loop {
-            let buf = &self.buffer[self.pos..self.len];
-
-            // Sound because 'b and 'c must outlive 'a so the buffer cannot be modified while someone has a ref on it
-            let buf: &'a [u8] = unsafe { std::mem::transmute(buf) };
-
-            match parser(buf) {
-                Ok((rem, value)) => {
-                    self.advance_with_slice(rem);
-                    return Ok(value);
-                },
-
-                Err(PcapParseError::IncompleteBuffer(_, _)) => {
-                    // The parsed data len should never be greater than the buffer capacity
-                    if buf.len() == self.buffer.len() {
-                        return Err(PcapReadError::Io(Error::from(ErrorKind::UnexpectedEof)));
-                    }
-
-                    let nb_read = self.fill_buf().map_err(PcapReadError::Io)?;
-                    if nb_read == 0 {
-                        return Err(PcapReadError::Io(Error::from(ErrorKind::UnexpectedEof)));
-                    }
-                },
-
-                Err(PcapParseError::Validation(val)) => return Err(PcapReadError::Validation(val)),
+                Err(e) => return Err(e.into_read_error()),
             }
         }
     }
@@ -174,6 +136,63 @@ impl<R: Read> ReadBuffer<R> {
     /// Return a reference over the inner reader
     pub fn get_ref(&self) -> &R {
         &self.reader
+    }
+}
+
+/* ----- ReadBufferParseError ----- */
+
+/// Adapter used by [`ReadBuffer::parse_with`] to share the buffered parsing loop
+/// between pcap and pcapng parsers while preserving their read error types.
+pub(crate) trait ReadBufferParseError {
+    /// Read-level error returned by the reader using this parse error.
+    type ReadError;
+
+    /// Returns true when parsing failed only because more input bytes are needed.
+    fn is_incomplete(&self) -> bool;
+    /// Converts an I/O error raised while filling the buffer into the read error.
+    fn from_io(error: Error) -> Self::ReadError;
+    /// Converts a terminal parse error into the read error returned to callers.
+    fn into_read_error(self) -> Self::ReadError;
+}
+
+impl ReadBufferParseError for PcapParseError {
+    type ReadError = PcapReadError;
+
+    #[inline]
+    fn is_incomplete(&self) -> bool {
+        matches!(self, Self::IncompleteBuffer(_, _))
+    }
+
+    #[inline]
+    fn from_io(error: Error) -> Self::ReadError {
+        PcapReadError::Io(error)
+    }
+
+    #[inline]
+    fn into_read_error(self) -> Self::ReadError {
+        match self {
+            Self::IncompleteBuffer(_, _) => PcapReadError::Io(Error::from(ErrorKind::UnexpectedEof)),
+            Self::Validation(val) => PcapReadError::Validation(val),
+        }
+    }
+}
+
+impl ReadBufferParseError for PcapNgParseError {
+    type ReadError = PcapNgReadError;
+
+    #[inline]
+    fn is_incomplete(&self) -> bool {
+        matches!(self, Self::IncompleteBuffer(_, _))
+    }
+
+    #[inline]
+    fn from_io(error: Error) -> Self::ReadError {
+        PcapNgReadError::Io(error)
+    }
+
+    #[inline]
+    fn into_read_error(self) -> Self::ReadError {
+        self.into()
     }
 }
 


### PR DESCRIPTION
- Replace duplicated `parse_with`/`parse_with2` loops with one generic `parse_with`
- Add parse-error adapter trait for pcap and pcapng read error conversion