### PR TITLE
Validate pcapng packet block consistency before parsing and writing

### DIFF
--- a/src/common.rs
+++ b/src/common.rs
@@ -30,8 +30,7 @@ impl Endianness {
     pub fn from_byteorder<B: ByteOrder>() -> Self {
         if B::read_u32(&[0, 0, 0, 1]) == 1 {
             Endianness::Big
-        }
-        else {
+        } else {
             Endianness::Little
         }
     }

--- a/src/pcapng/blocks/block_common.rs
+++ b/src/pcapng/blocks/block_common.rs
@@ -252,6 +252,7 @@ impl<'a> Block<'a> {
             writer: &mut W,
         ) -> Result<usize, PcapNgWriteError> {
             // Fake write to compute the data length
+            // It also do all the write checks, so any malformed block will fail before anything is written on the writer
             let data_len = block.write_to::<B, _>(state, &mut std::io::sink())?;
             let pad_len = (4 - (data_len % 4)) % 4;
 

--- a/src/pcapng/blocks/enhanced_packet.rs
+++ b/src/pcapng/blocks/enhanced_packet.rs
@@ -10,8 +10,8 @@ use derive_into_owned::IntoOwned;
 
 use super::block_common::{Block, PcapNgBlock};
 use super::opt_common::{CommonOption, PcapNgOption, WriteOpt};
-use crate::pcapng::PcapNgState;
 use crate::pcapng::errors::{BlockContentParseError, OptionEntryError, PcapNgWriteError};
+use crate::pcapng::{ContentValidationError, PcapNgState};
 
 /// An Enhanced Packet Block (EPB) is the standard container for storing the packets coming from the network.
 #[derive(Clone, Debug, Default, IntoOwned, Eq, PartialEq)]
@@ -26,6 +26,7 @@ pub struct EnhancedPacketBlock<'a> {
     pub timestamp: i128,
 
     /// Actual length of the packet when it was transmitted on the network.
+    /// Must be >= data.len().
     pub original_len: u32,
 
     /// The data coming from the network, including link-layer headers.
@@ -42,12 +43,20 @@ impl<'a> PcapNgBlock<'a> for EnhancedPacketBlock<'a> {
         }
 
         let interface_id = slice.read_u32::<B>().expect("slice length checked above");
+        if (interface_id as usize) >= state.interfaces.len() {
+            return Err(ContentValidationError::InvalidInterfaceId(interface_id).into());
+        }
+
         let timestamp_high = slice.read_u32::<B>().expect("slice length checked above");
         let timestamp_low = slice.read_u32::<B>().expect("slice length checked above");
         let timestamp = state.decode_timestamp(interface_id, timestamp_high, timestamp_low)?;
 
         let captured_len = slice.read_u32::<B>().expect("slice length checked above");
         let original_len = slice.read_u32::<B>().expect("slice length checked above");
+
+        if original_len < captured_len {
+            return Err(ContentValidationError::InvalidOriginalLen(original_len, captured_len as usize).into());
+        }
 
         let pad_len = (4 - (captured_len as usize % 4)) % 4;
         let tot_len = captured_len as usize + pad_len;
@@ -66,15 +75,30 @@ impl<'a> PcapNgBlock<'a> for EnhancedPacketBlock<'a> {
     }
 
     fn write_to<B: ByteOrder, W: Write>(&self, state: &PcapNgState, writer: &mut W) -> Result<usize, PcapNgWriteError> {
-        let pad_len = (4 - (&self.data.len() % 4)) % 4;
+        // Integrity checks are done before any writting to prevent invalid state in the file
+        if (self.interface_id as usize) >= state.interfaces.len() {
+            return Err(PcapNgWriteError::Validation {
+                field: "EnhancedPacketBlock.interface_id",
+                source: crate::pcapng::ContentValidationError::InvalidInterfaceId(self.interface_id),
+            });
+        }
 
-        writer.write_u32::<B>(self.interface_id)?;
+        if (self.original_len as usize) < self.data.len() {
+            return Err(PcapNgWriteError::Validation {
+                field: "EnhancedPacketBlock.original_len",
+                source: crate::pcapng::ContentValidationError::InvalidOriginalLen(self.original_len, self.data.len()),
+            });
+        }
+
         let (timestamp_high, timestamp_low) = state
             .encode_timestamp(self.interface_id, self.timestamp)
             .map_err(|source| PcapNgWriteError::Validation { field: "EnhancedPacketBlock.timestamp", source })?;
+
+        let pad_len = (4 - (&self.data.len() % 4)) % 4;
+
+        writer.write_u32::<B>(self.interface_id)?;
         writer.write_u32::<B>(timestamp_high)?;
         writer.write_u32::<B>(timestamp_low)?;
-
         writer.write_u32::<B>(self.data.len() as u32)?;
         writer.write_u32::<B>(self.original_len)?;
         writer.write_all(&self.data)?;

--- a/src/pcapng/blocks/interface_description.rs
+++ b/src/pcapng/blocks/interface_description.rs
@@ -63,7 +63,12 @@ impl<'a> PcapNgBlock<'a> for InterfaceDescriptionBlock<'a> {
     }
 
     fn write_to<B: ByteOrder, W: Write>(&self, state: &PcapNgState, writer: &mut W) -> Result<usize, PcapNgWriteError> {
-        writer.write_u16::<B>(u32::from(self.linktype) as u16)?;
+        let datalink: u16 = u32::from(self.linktype).try_into().map_err(|_| PcapNgWriteError::Validation {
+            field: "InterfaceDescriptionBlock.linktype",
+            source: ContentValidationError::InvalidLinktype(self.linktype),
+        })?;
+
+        writer.write_u16::<B>(datalink)?;
         writer.write_u16::<B>(0)?;
         writer.write_u32::<B>(self.snaplen)?;
 
@@ -84,12 +89,12 @@ impl<'a> InterfaceDescriptionBlock<'a> {
 
     /// Returns the timestamp resolution of the interface.
     /// If no ts_resolution is set, defaults to μs.
-    pub fn ts_resolution(&self) -> Result<TsResolution, ContentValidationError> {
-        let mut ts_resol = Ok(TsResolution::default());
+    pub fn ts_resolution(&self) -> TsResolution {
+        let mut ts_resol = TsResolution::default();
 
         for opt in &self.options {
             if let InterfaceDescriptionOption::IfTsResol(resol) = opt {
-                ts_resol = TsResolution::from_u8(*resol);
+                ts_resol = *resol;
                 break;
             }
         }
@@ -136,7 +141,7 @@ pub enum InterfaceDescriptionOption<'a> {
     IfSpeed(u64),
 
     /// The if_tsresol option identifies the resolution of timestamps.
-    IfTsResol(u8),
+    IfTsResol(TsResolution),
 
     /// The if_tzone option identifies the time zone for GMT support.
     IfTzone(u32),
@@ -224,7 +229,10 @@ impl<'a> PcapNgOption<'a> for InterfaceDescriptionOption<'a> {
                 if slice.len() != 1 {
                     return Err(OptionEntryError::WrongSize { expected: 1, actual: slice.len() });
                 }
-                InterfaceDescriptionOption::IfTsResol(slice.read_u8().unwrap())
+
+                let raw_resol = slice.read_u8().unwrap();
+                let resol = TsResolution::from_u8(raw_resol)?;
+                InterfaceDescriptionOption::IfTsResol(resol)
             },
             Self::IF_T_ZONE => {
                 if slice.len() != 4 {
@@ -273,7 +281,7 @@ impl<'a> PcapNgOption<'a> for InterfaceDescriptionOption<'a> {
             InterfaceDescriptionOption::IfMacAddr(a) => a.write_opt::<B, W>(Self::IF_MAC_ADDR, writer),
             InterfaceDescriptionOption::IfEuIAddr(a) => a.write_opt::<B, W>(Self::IF_EU_ADDR, writer),
             InterfaceDescriptionOption::IfSpeed(a) => a.write_opt::<B, W>(Self::IF_SPEED, writer),
-            InterfaceDescriptionOption::IfTsResol(a) => a.write_opt::<B, W>(Self::IF_TS_RESOL, writer),
+            InterfaceDescriptionOption::IfTsResol(a) => a.to_u8().write_opt::<B, W>(Self::IF_TS_RESOL, writer),
             InterfaceDescriptionOption::IfTzone(a) => a.write_opt::<B, W>(Self::IF_T_ZONE, writer),
             InterfaceDescriptionOption::IfFilter(a) => a.write_opt::<B, W>(Self::IF_FILTER, writer),
             InterfaceDescriptionOption::IfOs(a) => a.write_opt::<B, W>(Self::IF_OS, writer),

--- a/src/pcapng/blocks/interface_statistics.rs
+++ b/src/pcapng/blocks/interface_statistics.rs
@@ -46,10 +46,18 @@ impl<'a> PcapNgBlock<'a> for InterfaceStatisticsBlock<'a> {
     }
 
     fn write_to<B: ByteOrder, W: Write>(&self, state: &PcapNgState, writer: &mut W) -> Result<usize, PcapNgWriteError> {
-        writer.write_u32::<B>(self.interface_id)?;
+        if self.interface_id >= (state.interfaces.len() as u32) {
+            return Err(PcapNgWriteError::Validation {
+                field: "InterfaceStatisticsBlock.interface_id",
+                source: crate::pcapng::ContentValidationError::InvalidInterfaceId(self.interface_id),
+            });
+        }
+
         let (timestamp_high, timestamp_low) = state
             .encode_timestamp(self.interface_id, self.timestamp)
             .map_err(|source| PcapNgWriteError::Validation { field: "InterfaceStatisticsBlock.timestamp", source })?;
+
+        writer.write_u32::<B>(self.interface_id)?;
         writer.write_u32::<B>(timestamp_high)?;
         writer.write_u32::<B>(timestamp_low)?;
 

--- a/src/pcapng/blocks/packet.rs
+++ b/src/pcapng/blocks/packet.rs
@@ -10,7 +10,7 @@ use derive_into_owned::IntoOwned;
 
 use super::block_common::{Block, PcapNgBlock};
 use super::opt_common::{CommonOption, PcapNgOption, WriteOpt};
-use crate::pcapng::PcapNgState;
+use crate::pcapng::{ContentValidationError, PcapNgState};
 use crate::pcapng::errors::{BlockContentParseError, OptionEntryError, PcapNgWriteError};
 
 /// The Packet Block is obsolete, and MUST NOT be used in new files.
@@ -28,9 +28,6 @@ pub struct PacketBlock<'a> {
 
     /// Nanoseconds elapsed since 1970-01-01 00:00:00 UTC.
     pub timestamp: i128,
-
-    /// Number of octets captured from the packet (i.e. the length of the Packet Data field).
-    pub captured_len: u32,
 
     /// Actual length of the packet when it was transmitted on the network.
     pub original_len: u32,
@@ -56,6 +53,10 @@ impl<'a> PcapNgBlock<'a> for PacketBlock<'a> {
         let captured_len = slice.read_u32::<B>().unwrap();
         let original_len = slice.read_u32::<B>().unwrap();
 
+        if original_len < captured_len {
+            return Err(ContentValidationError::InvalidOriginalLen(original_len, captured_len as usize).into());
+        }
+
         let pad_len = (4 - (captured_len as usize % 4)) % 4;
         let tot_len = captured_len as usize + pad_len;
 
@@ -71,7 +72,6 @@ impl<'a> PcapNgBlock<'a> for PacketBlock<'a> {
             interface_id,
             drop_count,
             timestamp,
-            captured_len,
             original_len,
             data: Cow::Borrowed(data),
             options,
@@ -81,18 +81,34 @@ impl<'a> PcapNgBlock<'a> for PacketBlock<'a> {
     }
 
     fn write_to<B: ByteOrder, W: Write>(&self, state: &PcapNgState, writer: &mut W) -> Result<usize, PcapNgWriteError> {
-        writer.write_u16::<B>(self.interface_id)?;
-        writer.write_u16::<B>(self.drop_count)?;
+        // Integrity checks are done before any writting to prevent invalid state in the file
+        if (self.interface_id as usize) >= state.interfaces.len() {
+            return Err(PcapNgWriteError::Validation {
+                field: "PacketBlock.interface_id",
+                source: crate::pcapng::ContentValidationError::InvalidInterfaceId(self.interface_id as u32),
+            });
+        }
+
+        if (self.original_len as usize) < self.data.len() {
+            return Err(PcapNgWriteError::Validation {
+                field: "PacketBlock.original_len",
+                source: crate::pcapng::ContentValidationError::InvalidOriginalLen(self.original_len, self.data.len()),
+            });
+        }
+
         let (timestamp_high, timestamp_low) = state
             .encode_timestamp(self.interface_id as u32, self.timestamp)
             .map_err(|source| PcapNgWriteError::Validation { field: "PacketBlock.timestamp", source })?;
+
+        writer.write_u16::<B>(self.interface_id)?;
+        writer.write_u16::<B>(self.drop_count)?;
         writer.write_u32::<B>(timestamp_high)?;
         writer.write_u32::<B>(timestamp_low)?;
-        writer.write_u32::<B>(self.captured_len)?;
+        writer.write_u32::<B>(self.data.len() as u32)?;
         writer.write_u32::<B>(self.original_len)?;
         writer.write_all(&self.data)?;
 
-        let pad_len = (4 - (self.captured_len as usize % 4)) % 4;
+        let pad_len = (4 - (self.data.len() % 4)) % 4;
         writer.write_all(&[0_u8; 3][..pad_len])?;
 
         let opt_len = PacketOption::write_opts_to::<B, _>(&self.options, state, Some(self.interface_id as u32), writer)?;

--- a/src/pcapng/blocks/simple_packet.rs
+++ b/src/pcapng/blocks/simple_packet.rs
@@ -1,6 +1,7 @@
 //! Simple Packet Block (SPB).
 
 use std::borrow::Cow;
+use std::cmp::min;
 use std::io::Write;
 
 use byteorder_slice::ByteOrder;
@@ -9,8 +10,8 @@ use byteorder_slice::result::ReadSlice;
 use derive_into_owned::IntoOwned;
 
 use super::block_common::{Block, PcapNgBlock};
-use crate::pcapng::PcapNgState;
 use crate::pcapng::errors::{BlockContentParseError, PcapNgWriteError};
+use crate::pcapng::{ContentValidationError, PcapNgState};
 
 /// The Simple Packet Block (SPB) is a lightweight container for storing the packets coming from the network.
 ///
@@ -25,18 +26,71 @@ pub struct SimplePacketBlock<'a> {
 }
 
 impl<'a> PcapNgBlock<'a> for SimplePacketBlock<'a> {
-    fn from_slice<B: ByteOrder>(_state: &PcapNgState, mut slice: &'a [u8]) -> Result<(&'a [u8], Self), BlockContentParseError> {
+    fn from_slice<B: ByteOrder>(state: &PcapNgState, mut slice: &'a [u8]) -> Result<(&'a [u8], Self), BlockContentParseError> {
         if slice.len() < 4 {
             return Err(BlockContentParseError::BlockContentTooSmall { needed: 4, actual: slice.len() });
         }
 
-        let original_len = slice.read_u32::<B>().unwrap();
-        let packet = SimplePacketBlock { original_len, data: Cow::Borrowed(slice) };
+        // The interface of a simple packet is always the first interface of the section
+        let Some(interface) = state.interfaces.first() else {
+            return Err(ContentValidationError::NoInterface.into());
+        };
 
-        Ok((&[], packet))
+        let original_len = slice.read_u32::<B>().unwrap();
+
+        // Since the packet can be truncated, it's length is the minimum between snaplen (max captured length) and original_len (length on the wire).
+        // If snaplen is 0 then there was no limit.
+        let pkt_len = if interface.snaplen == 0 {
+            original_len as usize
+        } else {
+            min(original_len, interface.snaplen) as usize
+        };
+
+        let pad_len = (4 - (pkt_len % 4)) % 4;
+        let tot_len = pkt_len + pad_len;
+
+        if slice.len() < tot_len {
+            return Err(BlockContentParseError::BlockContentTooSmall { needed: tot_len, actual: slice.len() });
+        }
+
+        let data = slice.read_slice(pkt_len).expect("slice length checked above");
+        slice.move_forward(pad_len).expect("slice length checked above");
+
+        let packet = SimplePacketBlock { original_len, data: Cow::Borrowed(data) };
+
+        Ok((slice, packet))
     }
 
-    fn write_to<B: ByteOrder, W: Write>(&self, _state: &PcapNgState, writer: &mut W) -> Result<usize, PcapNgWriteError> {
+    fn write_to<B: ByteOrder, W: Write>(&self, state: &PcapNgState, writer: &mut W) -> Result<usize, PcapNgWriteError> {
+        // Check that original_len is always >= self.data.len()
+        if (self.original_len as usize) < self.data.len() {
+            return Err(PcapNgWriteError::Validation {
+                field: "SimplePacketBlock.original_len",
+                source: ContentValidationError::InvalidOriginalLen(self.original_len, self.data.len()),
+            });
+        }
+
+        // Check that original_length and data_len take snaplen into account //
+        let Some(interface) = state.interfaces.first() else {
+            return Err(PcapNgWriteError::Validation {
+                field: "SimplePacketBlock.interface",
+                source: ContentValidationError::NoInterface,
+            });
+        };
+
+        let expected_len = if interface.snaplen == 0 {
+            self.original_len as usize
+        } else {
+            min(self.original_len, interface.snaplen) as usize
+        };
+
+        if self.data.len() != expected_len {
+            return Err(PcapNgWriteError::Validation {
+                field: "SimplePacketBlock.data",
+                source: ContentValidationError::InvalidCapturedLen { expected: expected_len, actual: self.data.len() },
+            });
+        }
+
         writer.write_u32::<B>(self.original_len)?;
         writer.write_all(&self.data)?;
 
@@ -48,5 +102,101 @@ impl<'a> PcapNgBlock<'a> for SimplePacketBlock<'a> {
 
     fn into_block(self) -> Block<'a> {
         Block::SimplePacket(self)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::borrow::Cow;
+
+    use byteorder_slice::BigEndian;
+
+    use super::SimplePacketBlock;
+    use crate::DataLink;
+    use crate::pcapng::blocks::PcapNgBlock;
+    use crate::pcapng::blocks::interface_description::InterfaceDescriptionBlock;
+    use crate::pcapng::errors::{BlockContentParseError, PcapNgWriteError};
+    use crate::pcapng::{ContentValidationError, PcapNgState};
+
+    fn state_with_snaplen(snaplen: u32) -> PcapNgState {
+        let mut state = PcapNgState::default();
+        state.update_from_block(&InterfaceDescriptionBlock::new(DataLink::ETHERNET, snaplen).into_block());
+        state
+    }
+
+    #[test]
+    fn parse_rejects_simple_packet_without_interface() {
+        let data = [0, 0, 0, 4, 0, 1, 2, 3];
+        let err = SimplePacketBlock::from_slice::<BigEndian>(&PcapNgState::default(), &data).unwrap_err();
+
+        assert!(matches!(err, BlockContentParseError::Validation(ContentValidationError::NoInterface)));
+    }
+
+    #[test]
+    fn parse_truncates_simple_packet_to_snaplen_and_consumes_padding() {
+        let state = state_with_snaplen(2);
+        let data = [
+            0, 0, 0, 4, // original_len
+            0, 1, // captured packet data
+            0, 0, // padding
+        ];
+
+        let (rem, packet) = SimplePacketBlock::from_slice::<BigEndian>(&state, &data).unwrap();
+
+        assert_eq!(packet.original_len, 4);
+        assert_eq!(&packet.data[..], &[0, 1]);
+        assert!(rem.is_empty());
+    }
+
+    #[test]
+    fn write_rejects_simple_packet_without_interface() {
+        let packet = SimplePacketBlock { original_len: 4, data: Cow::Borrowed(&[0, 1, 2, 3]) };
+        let err = packet.write_to::<BigEndian, _>(&PcapNgState::default(), &mut Vec::new()).unwrap_err();
+
+        assert!(matches!(
+            err,
+            PcapNgWriteError::Validation {
+                field: "SimplePacketBlock.interface",
+                source: ContentValidationError::NoInterface,
+            }
+        ));
+    }
+
+    #[test]
+    fn write_rejects_simple_packet_shorter_than_expected_with_unlimited_snaplen() {
+        let state = state_with_snaplen(0);
+        let packet = SimplePacketBlock { original_len: 4, data: Cow::Borrowed(&[0, 1]) };
+        let err = packet.write_to::<BigEndian, _>(&state, &mut Vec::new()).unwrap_err();
+
+        assert!(matches!(
+            err,
+            PcapNgWriteError::Validation {
+                field: "SimplePacketBlock.data",
+                source: ContentValidationError::InvalidCapturedLen { expected: 4, actual: 2 },
+            }
+        ));
+    }
+
+    #[test]
+    fn write_accepts_simple_packet_truncated_to_snaplen() {
+        let state = state_with_snaplen(2);
+        let packet = SimplePacketBlock { original_len: 4, data: Cow::Borrowed(&[0, 1]) };
+
+        assert_eq!(packet.write_to::<BigEndian, _>(&state, &mut Vec::new()).unwrap(), 8);
+    }
+
+    #[test]
+    fn write_rejects_simple_packet_longer_than_snaplen() {
+        let state = state_with_snaplen(2);
+        let packet = SimplePacketBlock { original_len: 4, data: Cow::Borrowed(&[0, 1, 2]) };
+        let err = packet.write_to::<BigEndian, _>(&state, &mut Vec::new()).unwrap_err();
+
+        assert!(matches!(
+            err,
+            PcapNgWriteError::Validation {
+                field: "SimplePacketBlock.data",
+                source: ContentValidationError::InvalidCapturedLen { expected: 2, actual: 3 },
+            }
+        ));
     }
 }

--- a/src/pcapng/errors.rs
+++ b/src/pcapng/errors.rs
@@ -1,6 +1,6 @@
 use thiserror::Error;
 
-use crate::pcapng::blocks::interface_description::TsResolution;
+use crate::{DataLink, pcapng::blocks::interface_description::TsResolution};
 
 /* ----- PcapError ----- */
 
@@ -204,10 +204,6 @@ pub enum StateUpdateError {
     /// A state-relevant raw block could not be converted into a typed block.
     #[error("Failed to convert raw block to update the pcapng state")]
     BlockConversion(#[from] BlockConversionError),
-
-    /// A typed block failed state validation.
-    #[error("Failed to validate the pcapng state")]
-    Validation(#[from] ContentValidationError),
 }
 
 /* ----- ContentValidationError ----- */
@@ -224,12 +220,34 @@ pub enum ContentValidationError {
     /// The timestamp resolution value is invalid.
     #[error("Invalid timestamp resolution: {0:#X} (is_bin: {1}, resol:{2})")]
     InvalidTsResolution(u8, bool, u8),
+    /// The linktype in invalid (superior to u16::MAX)
+    #[error("Invalid Linktype: {0:?}")]
+    InvalidLinktype(DataLink),
+
+    /// No interface in the current section state.
+    #[error("Section without any interface")]
+    NoInterface,
     /// The interface ID does not exist in the current section state.
     #[error("Invalid interface ID: {0}")]
     InvalidInterfaceId(u32),
+
     /// The timestamp cannot be represented on the raw 64-bit timestamp field.
     #[error("Timestamp can't be represented on a u64: ts = {}ns, ts_resolution = {}, offset = {}s", .0, .1, .2)]
     InvalidTimestamp(i128, TsResolution, i64),
+
+    /// The original length of the packet is lower than its actual length
+    #[error("The original length of the packet is lower than its actual length: {0}B on wire, {1}B captured")]
+    InvalidOriginalLen(u32, usize),
+
+    /// The captured length of the packet does not match the expected length.
+    #[error("Invalid captured length: expected {expected}B, got {actual}B")]
+    InvalidCapturedLen {
+        /// Expected captured length
+        expected: usize,
+        /// Actual captured length
+        actual: usize,
+    },
+
     /// The Name Resolution record entry size is invalid.
     #[error("Wrong record size: expected {expected}B, got {actual}B")]
     RecordWrongSize {
@@ -255,12 +273,15 @@ pub enum ContentValidationError {
     /// A Name Resolution record does not contain any names.
     #[error("Record without any name")]
     RecordNamesEmpty,
+
     /// Error converting a custom block payload.
     #[error("Error in custom block conversion for PEN {0}: {1}")]
     CustomBlockConversionError(u32, Box<dyn std::error::Error + Sync + Send>),
+
     /// The content of a block is too big to fit on a block.
     #[error("Block content doesn't fit on a u32: {0}B")]
     BlockContentTooBig(u64),
+
     /// The content of a PcapNgOption is too big to be written
     #[error("Option content doesn't fit on a u16: {0}B")]
     OptionTooBig(usize),

--- a/src/pcapng/parser.rs
+++ b/src/pcapng/parser.rs
@@ -61,7 +61,7 @@ impl PcapNgParser {
             return Err(PcapNgFormatError::MissingSectionHeader.into());
         };
 
-        state.update_from_block(&block)?;
+        state.update_from_block(&block);
 
         let parser = PcapNgParser { state };
 
@@ -83,7 +83,7 @@ impl PcapNgParser {
             let state = &parser.state;
             let block = raw_block.try_into_block(state)?;
 
-            parser.state.update_from_block(&block)?;
+            parser.state.update_from_block(&block);
             Ok((rem, block))
         }
 

--- a/src/pcapng/state.rs
+++ b/src/pcapng/state.rs
@@ -47,7 +47,7 @@ impl PcapNgState {
     }
 
     /// Update the state based on the next [`Block`].
-    pub fn update_from_block(&mut self, block: &Block) -> Result<(), StateUpdateError> {
+    pub fn update_from_block(&mut self, block: &Block) {
         match block {
             Block::SectionHeader(blk) => {
                 self.section = blk.clone().into_owned();
@@ -55,14 +55,13 @@ impl PcapNgState {
                 self.ts_parameters.clear();
             },
             Block::InterfaceDescription(blk) => {
-                let ts_resolution = blk.ts_resolution()?;
+                let ts_resolution = blk.ts_resolution();
                 let ts_offset = blk.ts_offset();
                 self.ts_parameters.push((ts_resolution, ts_offset));
                 self.interfaces.push(blk.clone().into_owned());
             },
             _ => {},
         }
-        Ok(())
     }
 
     /// Update the state based on the next [`RawBlock`].
@@ -71,7 +70,7 @@ impl PcapNgState {
             SECTION_HEADER_BLOCK | INTERFACE_DESCRIPTION_BLOCK => {
                 let block = raw_block.clone().try_into_block_with_byteorder::<B>(self)?;
 
-                self.update_from_block(&block)?;
+                self.update_from_block(&block);
                 Ok(())
             },
             _ => Ok(()),

--- a/src/pcapng/writer.rs
+++ b/src/pcapng/writer.rs
@@ -7,7 +7,7 @@ use super::blocks::interface_description::InterfaceDescriptionBlock;
 use super::blocks::section_header::SectionHeaderBlock;
 use super::{PcapNgState, RawBlock};
 use crate::Endianness;
-use crate::pcapng::errors::{ContentValidationError, PcapNgWriteError};
+use crate::pcapng::errors::PcapNgWriteError;
 
 /// Write a PcapNg to a writer.
 ///
@@ -77,18 +77,18 @@ impl<W: Write> PcapNgWriter<W> {
 
         let block = section.into_owned().into_block();
 
-        state.update_from_block(&block)?;
-
         let _ = match endianness {
             Endianness::Big => block.write_to::<BigEndian, _>(&state, &mut writer),
             Endianness::Little => block.write_to::<LittleEndian, _>(&state, &mut writer),
         }?;
 
+        state.update_from_block(&block);
+
         Ok(Self { state, writer })
     }
 
     /// Write a [`Block`].
-    /// 
+    ///
     /// Errors are not recoverable because they can leave the Writer in a wrong state.
     ///
     /// # Example
@@ -120,36 +120,28 @@ impl<W: Write> PcapNgWriter<W> {
     /// pcap_ng_writer.write_block(&packet.into_block()).unwrap();
     /// ```
     pub fn write_block(&mut self, block: &Block) -> Result<usize, PcapNgWriteError> {
-        match block {
-            Block::InterfaceStatistics(blk) => {
-                if blk.interface_id as usize >= self.state.interfaces.len() {
-                    return Err(PcapNgWriteError::Validation {
-                        field: "InterfaceStatisticsBlock.interface_id",
-                        source: ContentValidationError::InvalidInterfaceId(blk.interface_id),
-                    });
-                }
-            },
-            Block::EnhancedPacket(blk) => {
-                if blk.interface_id as usize >= self.state.interfaces.len() {
-                    return Err(PcapNgWriteError::Validation {
-                        field: "EnhancedPacketBlock.interface_id",
-                        source: ContentValidationError::InvalidInterfaceId(blk.interface_id),
-                    });
-                }
-            },
+        // The order of operation is important to prevent writing invalid files in case of error.
+        // The state is updated only after a successful write.
+        // The endianess is determined before the write to handle endianness changes when a new SectionHeader is encountered in the block list.
 
-            _ => (),
-        }
+        let endianess = if let Block::SectionHeader(sec_hdr) = block {
+            sec_hdr.endianness
+        } else {
+            self.state.section.endianness
+        };
 
-        self.state.update_from_block(block)?;
-        match self.state.section.endianness {
-            Endianness::Big => block.write_to::<BigEndian, _>(&self.state, &mut self.writer),
-            Endianness::Little => block.write_to::<LittleEndian, _>(&self.state, &mut self.writer),
-        }
+        let nb_written = match endianess {
+            Endianness::Big => block.write_to::<BigEndian, _>(&self.state, &mut self.writer)?,
+            Endianness::Little => block.write_to::<LittleEndian, _>(&self.state, &mut self.writer)?,
+        };
+
+        self.state.update_from_block(block);
+
+        Ok(nb_written)
     }
 
     /// Write a [`PcapNgBlock`].
-    /// 
+    ///
     /// Errors are not recoverable because they can leave the Writer in a wrong state.
     ///
     /// # Example
@@ -185,11 +177,14 @@ impl<W: Write> PcapNgWriter<W> {
     }
 
     /// Write a [`RawBlock`].
-    /// 
+    ///
     /// Errors are not recoverable because they can leave the Writer in a wrong state.
     ///
     /// Doesn't check the validity of the written blocks.
     pub fn write_raw_block(&mut self, block: &RawBlock) -> Result<usize, PcapNgWriteError> {
+        // TODO: handle state update failure
+        // Does raw parsing need to update state at all ?
+
         // Update state before write to handle endianess changes when a new SectionHeader is encountered
         match self.state.section.endianness {
             Endianness::Big => {

--- a/tests/negative_timestamp_offset.rs
+++ b/tests/negative_timestamp_offset.rs
@@ -2,7 +2,7 @@ use std::borrow::Cow;
 
 use pcap_file::DataLink;
 use pcap_file::pcapng::blocks::enhanced_packet::EnhancedPacketBlock;
-use pcap_file::pcapng::blocks::interface_description::{InterfaceDescriptionBlock, InterfaceDescriptionOption};
+use pcap_file::pcapng::blocks::interface_description::{InterfaceDescriptionBlock, InterfaceDescriptionOption, TsResolution};
 use pcap_file::pcapng::blocks::{Block, PcapNgBlock};
 use pcap_file::pcapng::{PcapNgReader, PcapNgWriter};
 
@@ -11,7 +11,7 @@ fn writer_roundtrip_preserves_negative_timestamp_offset() {
     let interface = InterfaceDescriptionBlock {
         linktype: DataLink::ETHERNET,
         snaplen: 0xFFFF,
-        options: vec![InterfaceDescriptionOption::IfTsResol(9), InterfaceDescriptionOption::IfTsOffset(-2)],
+        options: vec![InterfaceDescriptionOption::IfTsResol(TsResolution::NANO), InterfaceDescriptionOption::IfTsOffset(-2)],
     };
 
     let packet = EnhancedPacketBlock {

--- a/tests/pcapng/mod.rs
+++ b/tests/pcapng/mod.rs
@@ -422,7 +422,7 @@ fn test_stateful_custom_block() {
     let interface_description = InterfaceDescriptionBlock {
         linktype: DataLink::ETHERNET,
         snaplen: 1500,
-        options: vec![InterfaceDescriptionOption::IfTsResol(9)],
+        options: vec![InterfaceDescriptionOption::IfTsResol(TsResolution::NANO)],
     };
 
     pcapng_writer

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -2,7 +2,7 @@
 
 use std::fs::File;
 
-use pcap_file::pcapng::{PcapNgReader, blocks::interface_description::InterfaceDescriptionOption};
+use pcap_file::pcapng::{PcapNgReader, blocks::interface_description::{InterfaceDescriptionOption, TsResolution}};
 
 mod pcap;
 mod pcapng;
@@ -20,11 +20,11 @@ fn timestamp_resolution() {
         match i {
             0 => {
                 let if_en0 = block.as_interface_description().expect("Block 0 should be an InterfaceDescriptionBlock");
-                assert!(matches!(if_en0.options[2], InterfaceDescriptionOption::IfTsResol(9)), "Invalid TsResolution for block 0");
+                assert!(matches!(if_en0.options[2], InterfaceDescriptionOption::IfTsResol(TsResolution::NANO)), "Invalid TsResolution for block 0");
             },
             7 => {
                 let if_utun4 = block.as_interface_description().expect("Block 7 should be an InterfaceDescriptionBlock");
-                assert_eq!(if_utun4.options[1], InterfaceDescriptionOption::IfTsResol(6), "Invalid TsResolution for block 7");
+                assert_eq!(if_utun4.options[1], InterfaceDescriptionOption::IfTsResol(TsResolution::MICRO), "Invalid TsResolution for block 7");
             },
             8 => {
                 let pkt_0 = block.as_enhanced_packet().expect("Block 8 should be an EnhancedPacketBlock");


### PR DESCRIPTION
- Enhanced Packet Block: validate interface IDs, reject invalid original lengths, and run checks before writing
- Packet Block: validate interface IDs, reject invalid original lengths, and derive captured length from data
- Simple Packet Block: resolve packet length from snaplen, reject missing interfaces, validate captured length, and cover snaplen/padding cases
- Interface blocks: type if_tsresol as TsResolution and validate linktype/interface IDs before writing
- Writer/state: update typed writer state only after successful writes and make typed state updates infallible