### PR TITLE
Keep raw pcapng writer state consistent on write failure

### DIFF
--- a/src/pcapng/parser.rs
+++ b/src/pcapng/parser.rs
@@ -109,7 +109,11 @@ impl PcapNgParser {
             src: &'a [u8],
         ) -> Result<(&'a [u8], RawBlock<'a>), PcapNgParseError> {
             let (rem, raw_block) = RawBlock::from_slice::<B>(src)?;
-            parser.state.update_from_raw_block::<B>(&raw_block)?;
+
+            if let Some(block) = parser.state.decode_block_if_needed(&raw_block)? {
+                parser.state.update_from_block(&block);
+            }
+            
             Ok((rem, raw_block))
         }
 

--- a/src/pcapng/state.rs
+++ b/src/pcapng/state.rs
@@ -1,15 +1,13 @@
-use byteorder_slice::ByteOrder;
-
 use super::blocks::block_common::{Block, RawBlock};
 use super::blocks::interface_description::{InterfaceDescriptionBlock, TsResolution};
 use super::blocks::section_header::SectionHeaderBlock;
 use super::blocks::{INTERFACE_DESCRIPTION_BLOCK, SECTION_HEADER_BLOCK};
+use crate::Endianness;
 use crate::pcapng::errors::{ContentValidationError, StateUpdateError};
 
 #[cfg(doc)]
 use {
     super::blocks::interface_description::InterfaceDescriptionOption,
-    crate::Endianness,
     crate::pcapng::{PcapNgReader, PcapNgWriter},
 };
 
@@ -23,7 +21,9 @@ use {
 /// Normally this state is maintained internally by a [`PcapNgReader`] or
 /// [`PcapNgWriter`], but it's also possible to create a new [`PcapNgState`]
 /// with [`PcapNgState::default`], and then update it by calling
-/// [`PcapNgState::update_from_block`] or [`PcapNgState::update_from_raw_block`].
+/// [`PcapNgState::update_from_block`]. For raw blocks, call
+/// [`PcapNgState::decode_block_if_needed`] first, then update the state with
+/// the decoded block when one is returned.
 ///
 #[derive(Debug, Default)]
 pub struct PcapNgState {
@@ -46,6 +46,24 @@ impl PcapNgState {
         &self.interfaces[..]
     }
 
+    /// Returns the endiabness of the current section.
+    pub fn endianness(&self) -> Endianness {
+        self.section.endianness
+    }
+
+    /// Decode the given [`RawBlock`] if it contains state information.
+    ///
+    /// Returns [`None`] for blocks that don't affect the state.
+    pub fn decode_block_if_needed<'a>(&self, raw_block: &RawBlock<'a>) -> Result<Option<Block<'a>>, StateUpdateError> {
+        match raw_block.type_ {
+            SECTION_HEADER_BLOCK | INTERFACE_DESCRIPTION_BLOCK => {
+                let block = raw_block.clone().try_into_block(self)?;
+                Ok(Some(block))
+            },
+            _ => Ok(None),
+        }
+    }
+
     /// Update the state based on the next [`Block`].
     pub fn update_from_block(&mut self, block: &Block) {
         match block {
@@ -64,16 +82,13 @@ impl PcapNgState {
         }
     }
 
-    /// Update the state based on the next [`RawBlock`].
-    pub fn update_from_raw_block<B: ByteOrder>(&mut self, raw_block: &RawBlock) -> Result<(), StateUpdateError> {
-        match raw_block.type_ {
-            SECTION_HEADER_BLOCK | INTERFACE_DESCRIPTION_BLOCK => {
-                let block = raw_block.clone().try_into_block_with_byteorder::<B>(self)?;
-
-                self.update_from_block(&block);
-                Ok(())
-            },
-            _ => Ok(()),
+    /// Return the endianness to use to write the [`Block`].
+    ///
+    /// Takes an optional block as an argument to be used in conjunction with [`Self::decode_block_if_needed`].
+    pub fn block_endianness(&self, block: Option<&Block>) -> Endianness {
+        match block {
+            Some(Block::SectionHeader(block)) => block.endianness,
+            _ => self.endianness(),
         }
     }
 

--- a/src/pcapng/writer.rs
+++ b/src/pcapng/writer.rs
@@ -124,11 +124,7 @@ impl<W: Write> PcapNgWriter<W> {
         // The state is updated only after a successful write.
         // The endianess is determined before the write to handle endianness changes when a new SectionHeader is encountered in the block list.
 
-        let endianess = if let Block::SectionHeader(sec_hdr) = block {
-            sec_hdr.endianness
-        } else {
-            self.state.section.endianness
-        };
+        let endianess = self.state.block_endianness(Some(block));
 
         let nb_written = match endianess {
             Endianness::Big => block.write_to::<BigEndian, _>(&self.state, &mut self.writer)?,
@@ -181,31 +177,24 @@ impl<W: Write> PcapNgWriter<W> {
     /// Errors are not recoverable because they can leave the Writer in a wrong state.
     ///
     /// Doesn't check the validity of the written blocks.
-    pub fn write_raw_block(&mut self, block: &RawBlock) -> Result<usize, PcapNgWriteError> {
-        // TODO: handle state update failure
-        // Does raw parsing need to update state at all ?
-
-        // Update state before write to handle endianess changes when a new SectionHeader is encountered
-        match self.state.section.endianness {
-            Endianness::Big => {
-                self.state.update_from_raw_block::<BigEndian>(block)?;
-            },
-            Endianness::Little => {
-                self.state.update_from_raw_block::<LittleEndian>(block)?;
-            },
-        }
+    pub fn write_raw_block(&mut self, raw_block: &RawBlock) -> Result<usize, PcapNgWriteError> {
+        // The order of operation is important to prevent writing invalid files in case of error.
+        // The state is updated only after a successful write.
+        // The endianess is determined before the write to handle endianness changes when a new SectionHeader is encountered in the block list.
+        let opt_block = self.state.decode_block_if_needed(raw_block)?;
+        let endianess = self.state.block_endianness(opt_block.as_ref());
 
         // Write the block to the writer
-        match self.state.section.endianness {
-            Endianness::Big => {
-                let written = block.write_to::<BigEndian, _>(&mut self.writer)?;
-                Ok(written)
-            },
-            Endianness::Little => {
-                let written = block.write_to::<LittleEndian, _>(&mut self.writer)?;
-                Ok(written)
-            },
+        let nb_written = match endianess {
+            Endianness::Big => raw_block.write_to::<BigEndian, _>(&mut self.writer)?,
+            Endianness::Little => raw_block.write_to::<LittleEndian, _>(&mut self.writer)?,
+        };
+
+        if let Some(block) = opt_block {
+            self.state.update_from_block(&block);
         }
+
+        Ok(nb_written)
     }
 
     /// Consume [`self`], returning the wrapped writer.


### PR DESCRIPTION
- Raw writer:
  - Decode state-changing raw blocks before writing without mutating state
  - Choose write endianness from the decoded block when needed
  - Update writer state only after the raw block is written successfully

- Parser and state:
  - Share raw state decoding through decode_block_if_needed
  - Replace the mutating raw state update helper with explicit decode-then-update flow
  - Document how raw blocks should update PcapNgState